### PR TITLE
CCM-1476

### DIFF
--- a/docs/tests/production/index.md
+++ b/docs/tests/production/index.md
@@ -8,3 +8,4 @@
 * [POST /v1/message-batches](post_v1_message-batches/index.md)
   * [Validation Tests](post_v1_message-batches/validation.md)
   * [Performance Tests](post_v1_message-batches/performance.md)
+  * [Invalid Routing Plans](post_v1_message-batches/invalid_routing_plans.md)

--- a/docs/tests/production/post_v1_message-batches/index.md
+++ b/docs/tests/production/post_v1_message-batches/index.md
@@ -2,3 +2,4 @@
 
 * [Validation Tests](validation.md)
 * [Performance Tests](performance.md)
+* [Invalid Routing Plans](invalid_routing_plans.md)

--- a/docs/tests/production/post_v1_message-batches/invalid_routing_plans.md
+++ b/docs/tests/production/post_v1_message-batches/invalid_routing_plans.md
@@ -1,0 +1,7 @@
+# Invalid Routing Plans
+
+
+### Test no such routing plan
+
+
+### Test using someone elses routing plan

--- a/docs/tests/production/post_v1_message-batches/validation.md
+++ b/docs/tests/production/post_v1_message-batches/validation.md
@@ -1,6 +1,6 @@
 # Validation Tests
 
-### production.create_message_batches.test_field_validation.DOB *= ['1990-10-1', '1990-1-10', '90-10-10', '10-12-1990', '1-MAY-2000', '1990/01/01', '', [], {}, 5, 0.1]*
+### production.create_message_batches.test_field_validation.INVALID_DOB *= ['1990-10-1', '1990-1-10', '90-10-10', '10-12-1990', '1-MAY-2000', '1990/01/01', '', [], {}, 5, 0.1]*
 
 Invalid body 400 tests
 

--- a/tests/docs/production/post_v1_message-batches/index.rst
+++ b/tests/docs/production/post_v1_message-batches/index.rst
@@ -6,3 +6,4 @@ POST /v1/message-batches
 
    validation
    performance
+   invalid_routing_plans

--- a/tests/docs/production/post_v1_message-batches/invalid_routing_plans.rst
+++ b/tests/docs/production/post_v1_message-batches/invalid_routing_plans.rst
@@ -1,0 +1,6 @@
+Invalid Routing Plans
+=====================
+
+.. automodule:: production.create_message_batches.test_invalid_routing_config
+    :noindex:
+    :members:

--- a/tests/production/create_message_batches/test_field_validation.py
+++ b/tests/production/create_message_batches/test_field_validation.py
@@ -2,16 +2,15 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Permutations, Generators, Authentication
-from lib.constants import *
+import lib.constants as constants
 
 headers = {
     "Accept": "application/json",
     "Content-Type": "application/json"
 }
-CORRELATION_IDS = [None, "e8bb49c6-06bc-44f7-8443-9244284640f8"]
 INVALID_MESSAGE_VALUES = ["", [], 5, 0.1]
-NHS_NUMBER = ["012345678", "01234567890", "abcdefghij", "", [], {}, 5, 0.1]
-DOB = ["1990-10-1", "1990-1-10", "90-10-10", "10-12-1990", "1-MAY-2000", "1990/01/01", "", [], {}, 5, 0.1]
+INVALID_NHS_NUMBER = ["012345678", "01234567890", "abcdefghij", "", [], {}, 5, 0.1]
+INVALID_DOB = ["1990-10-1", "1990-1-10", "90-10-10", "10-12-1990", "1-MAY-2000", "1990/01/01", "", [], {}, 5, 0.1]
 
 
 """
@@ -20,13 +19,13 @@ Invalid body 400 tests
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_invalid_body(correlation_id):
     """
     .. py:function:: Test invalid body
     """
     resp = requests.post(
-        f"{PROD_URL}/v1/message-batches",
+        f"{constants.PROD_URL}/v1/message-batches",
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
@@ -47,31 +46,19 @@ def test_invalid_body(correlation_id):
 Missing property 400 test
 """
 
-_missing_properties = [
-    ("data", "/data"),
-    ("type", "/data/type"),
-    ("attributes", "/data/attributes"),
-    ("routingPlanId", "/data/attributes/routingPlanId"),
-    ("messageBatchReference", "/data/attributes/messageBatchReference"),
-    ("messages", "/data/attributes/messages"),
-    ("messageReference", "/data/attributes/messages/0/messageReference"),
-    ("recipient", "/data/attributes/messages/0/recipient"),
-    ("nhsNumber", "/data/attributes/messages/0/recipient/nhsNumber"),
-]
-
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize(
     "property, pointer",
-    _missing_properties
+    constants.MISSING_PROPERTIES_PATHS
 )
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_property_missing(property, pointer, correlation_id):
     """
     .. py:function:: Test missing properties
     """
     resp = requests.post(
-        f"{PROD_URL}/v1/message-batches",
+        f"{constants.PROD_URL}/v1/message-batches",
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
@@ -95,25 +82,19 @@ def test_property_missing(property, pointer, correlation_id):
 Null data 400 test
 """
 
-_null_properties = [
-    ("data", "/data"),
-    ("attributes", "/data/attributes"),
-    ("recipient", "/data/attributes/messages/0/recipient"),
-]
-
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize(
     "property, pointer",
-    _null_properties
+    constants.NULL_PROPERTIES_PATHS
 )
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_data_null(property, pointer, correlation_id):
     """
     .. py:function:: Test null properties
     """
     resp = requests.post(
-        f"{PROD_URL}/v1/message-batches",
+        f"{constants.PROD_URL}/v1/message-batches",
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
@@ -137,31 +118,19 @@ def test_data_null(property, pointer, correlation_id):
 Invalid data 400 test
 """
 
-_invalid_properties = [
-    ("type", "/data/type"),
-    ("routingPlanId", "/data/attributes/routingPlanId"),
-    ("messageBatchReference", "/data/attributes/messageBatchReference"),
-    ("messages", "/data/attributes/messages"),
-    ("messageReference", "/data/attributes/messages/0/messageReference"),
-    ("recipient", "/data/attributes/messages/0/recipient"),
-    ("nhsNumber", "/data/attributes/messages/0/recipient/nhsNumber"),
-    ("dateOfBirth", "/data/attributes/messages/0/recipient/dateOfBirth"),
-    ("personalisation", "/data/attributes/messages/0/personalisation"),
-]
-
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize(
     "property, pointer",
-    _invalid_properties
+    constants.INVALID_PROPERTIES_PATHS
 )
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_data_invalid(property, pointer, correlation_id):
     """
     .. py:function:: Test invalid properties
     """
     resp = requests.post(
-        f"{PROD_URL}/v1/message-batches",
+        f"{constants.PROD_URL}/v1/message-batches",
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
@@ -186,17 +155,13 @@ def test_data_invalid(property, pointer, correlation_id):
 Duplicate data 400 test
 """
 
-_duplicate_properties = [
-    ("messageReference", "/data/attributes/messages/1/messageReference"),
-]
-
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize(
     "property, pointer",
-    _duplicate_properties
+    constants.DUPLICATE_PROPERTIES_PATHS
 )
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_data_duplicate(property, pointer, correlation_id):
     """
     .. py:function:: Test duplicate data
@@ -207,7 +172,7 @@ def test_data_duplicate(property, pointer, correlation_id):
 
     # Post the same message a 2nd time to trigger the duplicate error
     resp = requests.post(
-        f"{PROD_URL}/v1/message-batches",
+        f"{constants.PROD_URL}/v1/message-batches",
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
@@ -228,23 +193,19 @@ def test_data_duplicate(property, pointer, correlation_id):
 Too few items 400 test
 """
 
-_too_few_properties = [
-    ("messages", "/data/attributes/messages"),
-]
-
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize(
     "property, pointer",
-    _too_few_properties
+    constants.TOO_FEW_PROPERTIES_PATHS
 )
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_data_too_few_items(property, pointer, correlation_id):
     """
     .. py:function:: Test too few items
     """
     resp = requests.post(
-        f"{PROD_URL}/v1/message-batches",
+        f"{constants.PROD_URL}/v1/message-batches",
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
@@ -266,13 +227,13 @@ def test_data_too_few_items(property, pointer, correlation_id):
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("nhs_number", NHS_NUMBER)
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("nhs_number", INVALID_NHS_NUMBER)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_invalid_nhs_number(nhs_number, correlation_id):
     """
     .. py:function:: Test invalid NHS numbers
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"
@@ -299,19 +260,19 @@ def test_invalid_nhs_number(nhs_number, correlation_id):
     Assertions.assert_error_with_optional_correlation_id(
         resp,
         400,
-        Generators.generate_invalid_value_error("/data/attributes/messages/0/recipient/nhsNumber"),
+        Generators.generate_invalid_nhs_number_error("/data/attributes/messages/0/recipient/nhsNumber"),
         correlation_id
     )
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("dob", DOB)
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("dob", INVALID_DOB)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_invalid_dob(dob, correlation_id):
     """
     .. py:function:: Test invalid dates of births
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"
@@ -325,7 +286,7 @@ def test_invalid_dob(dob, correlation_id):
                     {
                         "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
                         "recipient": {
-                            "nhsNumber": "0123456789",
+                            "nhsNumber": "9990548609",
                             "dateOfBirth": dob
                         },
                         "personalisation": {}
@@ -344,12 +305,12 @@ def test_invalid_dob(dob, correlation_id):
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_invalid_routing_plan(correlation_id):
     """
     .. py:function:: Test invalid routing plan identifier
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"
@@ -363,7 +324,7 @@ def test_invalid_routing_plan(correlation_id):
                     {
                         "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
                         "recipient": {
-                            "nhsNumber": "0123456789",
+                            "nhsNumber": "9990548609",
                             "dateOfBirth": "2000-01-01"
                         },
                         "personalisation": {}
@@ -382,12 +343,12 @@ def test_invalid_routing_plan(correlation_id):
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_invalid_message_batch_reference(correlation_id):
     """
     .. py:function:: Test invalid message batch reference value
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"
@@ -401,7 +362,7 @@ def test_invalid_message_batch_reference(correlation_id):
                     {
                         "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
                         "recipient": {
-                            "nhsNumber": "0123456789",
+                            "nhsNumber": "9990548609",
                             "dateOfBirth": "2000-01-01"
                         },
                         "personalisation": {}
@@ -420,12 +381,12 @@ def test_invalid_message_batch_reference(correlation_id):
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_invalid_message_reference(correlation_id):
     """
     .. py:function:: Test invalid message reference value
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"
@@ -439,7 +400,7 @@ def test_invalid_message_reference(correlation_id):
                     {
                         "messageReference": "invalid",
                         "recipient": {
-                            "nhsNumber": "0123456789",
+                            "nhsNumber": "9990548609",
                             "dateOfBirth": "2000-01-01"
                         },
                         "personalisation": {}
@@ -459,12 +420,12 @@ def test_invalid_message_reference(correlation_id):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("invalid_value", INVALID_MESSAGE_VALUES)
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_blank_value_under_messages(invalid_value, correlation_id):
     """
     .. py:function:: Test blank messages value
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"
@@ -490,12 +451,12 @@ def test_blank_value_under_messages(invalid_value, correlation_id):
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 def test_null_value_under_messages(correlation_id):
     """
     .. py:function:: Test null messages value
     """
-    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+    resp = requests.post(f"{constants.PROD_URL}/v1/message-batches", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
             "Authorization": f"{Authentication.generate_authentication('prod')}"

--- a/tests/production/create_message_batches/test_invalid_routing_config.py
+++ b/tests/production/create_message_batches/test_invalid_routing_config.py
@@ -1,0 +1,83 @@
+import requests
+import pytest
+import uuid
+from lib import Assertions, Generators, Authentication
+from lib.constants import PROD_URL
+
+CORRELATION_IDS = [None, "228aac39-542d-4803-b28e-5de9e100b9f8"]
+METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+INVALID_ROUTING_PLAN = "acd3d4b9-de96-49ef-9ab9-8ce03e678082"
+
+
+@pytest.mark.prodtest
+@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+def test_no_such_routing_plan(correlation_id):
+    """
+    .. py:function:: Test no such routing plan
+    """
+    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+            "Authorization": f"{Authentication.generate_authentication('prod')}",
+            "X-Correlation-Id": correlation_id
+        }, json={
+        "data": {
+            "type": "MessageBatch",
+            "attributes": {
+                "routingPlanId": f"f{str(uuid.uuid1())[1:]}",
+                "messageBatchReference": str(uuid.uuid1()),
+                "messages": [
+                    {
+                        "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1575",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "1982-03-17"
+                        },
+                        "personalisation": {}
+                    }
+                ]
+            }
+        }
+    })
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        404,
+        Generators.generate_no_such_routing_plan_error(),
+        correlation_id
+    )
+
+
+@pytest.mark.prodtest
+@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+def test_routing_plan_not_belonging_to_client_id(correlation_id):
+    """
+    .. py:function:: Test using someone elses routing plan
+    """
+    resp = requests.post(f"{PROD_URL}/v1/message-batches", headers={
+            "Authorization": f"{Authentication.generate_authentication('prod')}",
+            "X-Correlation-Id": correlation_id
+        }, json={
+        "data": {
+            "type": "MessageBatch",
+            "attributes": {
+                "routingPlanId": INVALID_ROUTING_PLAN,
+                "messageBatchReference": str(uuid.uuid1()),
+                "messages": [
+                    {
+                        "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1575",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "1982-03-17"
+                        },
+                        "personalisation": {}
+                    }
+                ]
+            }
+        }
+    })
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        404,
+        Generators.generate_no_such_routing_plan_error(),
+        correlation_id
+    )


### PR DESCRIPTION
## Summary
Adds test cases to ensure that our production client cannot access routing plans that do not exist, and that we cannot access routing plans for other clients.

This also fixes some production tests that do not pass now that 4.2.0 has gone live - they were not updated to include the NHS number validation changes required for the new checksum checking.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
