### PR TITLE
CCM-1616 - Service bans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ release: clean publish build-proxy
 
 #Serve the OAS specification
 serve:
+	npm run publish
 	(sleep 5; python3 -m webbrowser http://127.0.0.1:5000) &
 	npm run serve
 

--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -13,26 +13,26 @@ The following diagram details the proxy flow:
 
 ```mermaid
 flowchart
-    S[Request] --> QSA["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#quotas--spike-arrests'>Quotas & Spike Arrests</a>"]
+    S[Request] --> QSA["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#quotas--spike-arrests'>Quotas & Spike Arrests</a>"]
     QSA --> E1{Exception thrown?}
-    QSA --> OPF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#options-preflight'>Options PreFlight</a>"]
+    QSA --> OPF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#options-preflight'>Options PreFlight</a>"]
     OPF --> E1
-    OPF --> APTP["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#add-payload-to-ping-ping-endpoint'>Add Payload to Ping</a>"]
+    OPF --> APTP["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#add-payload-to-ping-ping-endpoint'>Add Payload to Ping</a>"]
     APTP --> E1
-    APTP --> SE["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#status-endpoint'>Status Endpoint</a>"]
+    APTP --> SE["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#status-endpoint'>Status Endpoint</a>"]
     SE --> E1
-    SE --> RT["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#request-routing'>Follow endpoint routing config</a>"]
+    SE --> RT["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#request-routing'>Follow endpoint routing config</a>"]
     RT --> E1
-    RT --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#set-response-defaults'>Set Response Defaults</a>"]
-    RT --> CALL["Callout to <a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#target-definition'>communications-manager-target</a>"]
+    RT --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set Response Defaults</a>"]
+    RT --> CALL["Callout to <a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#target-definition'>communications-manager-target</a>"]
     SRD --> E1
-    E1 --> |Yes| PRF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#proxy-fault-rules'>Proxy Fault Rules</a>"]
+    E1 --> |Yes| PRF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#proxy-fault-rules'>Proxy Fault Rules</a>"]
     PRF --> E2{Exception handled?}
     SRD --> R[Response]
     E2 --> |Yes| R
-    E2 --> |No| PDFR["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#proxy-default-fault-rule'>Proxy Default Fault Rule</a>"]
+    E2 --> |No| PDFR["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#proxy-default-fault-rule'>Proxy Default Fault Rule</a>"]
     PDFR --> R
-    R --> PCF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#post-client-flow'>Post Client Flow</a>"]
+    R --> PCF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#post-client-flow'>Post Client Flow</a>"]
     PCF --> E[End]
 ```
 
@@ -46,16 +46,16 @@ This diagram details the target definition flow:
 
 ```mermaid
 flowchart
-    S[Request] --> TPFR["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#target-preflow-request'>Target PreFlow Request</a>"]
+    S[Request] --> TPFR["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#target-preflow-request'>Target PreFlow Request</a>"]
     TPFR --> E1{Exception thrown?}
-    TPFR --> CMB["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#create-message-batch'>Create Message Batch</a>"]
+    TPFR --> CMB["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#create-message-batch'>Create Message Batch</a>"]
     CMB --> E1
-    CMB --> TPFRESP["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#target-preflow-response'>Target PreFlow Response</a>"]
+    CMB --> TPFRESP["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#target-preflow-response'>Target PreFlow Response</a>"]
     TPFRESP --> E1
-    TPFRESP --> TPOSTF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#target-post-flow'>Target Post Flow</a>"]
+    TPFRESP --> TPOSTF["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#target-post-flow'>Target Post Flow</a>"]
     TPOSTF --> E1
     TPOSTF --> E[End]
-    E1 --> |Yes| TFR["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#target-fault-rules'>Target Fault Rules</a>"]
+    E1 --> |Yes| TFR["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#target-fault-rules'>Target Fault Rules</a>"]
     TFR --> E
 ```
 
@@ -188,7 +188,7 @@ Source: [proxies/shared/partials/Partial.Proxy.FaultRules.xml](https://github.co
 
 ```mermaid
 flowchart LR
-    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#set-response-defaults'>Set response defaults</a>"]
+    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set response defaults</a>"]
     SRD --> Q1{Is SpikeArrestViolation?}
     Q1 --> |Yes| 429["Throw 429
 
@@ -207,7 +207,7 @@ Source: [proxies/shared/partials/Partial.Faults.DefaultFaultRule.xml](https://gi
 
 ```mermaid
 flowchart LR
-    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#set-response-defaults'>Set response defaults</a>"]
+    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set response defaults</a>"]
     SRD --> CAM["Error message catch all
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/AssignMessage.Errors.CatchAllMessage.xml'>AssignMessage.Errors.CatchAllMessage</a></em>"]
@@ -242,7 +242,7 @@ flowchart LR
     Q2 --> |Yes| NR
     Q2 --> |No| Q3{Is status endpoint?}
     Q3 --> |Yes| NR
-    Q3 --> |No| TS[Call <a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#target-definition'>communications-manager-target</a>]
+    Q3 --> |No| TS[Call <a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#target-definition'>communications-manager-target</a>]
     NR --> E[End]
     TS --> E[End]
 ```
@@ -276,7 +276,7 @@ Source: [proxies/shared/partials/Partial.Target.PreFlowRequest.xml](https://gith
 
 ```mermaid
 flowchart
-    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#set-response-defaults'>Set response defaults</a>"]
+    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set response defaults</a>"]
     SRD --> SBCI["Set the backend request correlation id
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/JavaScript.SetBackendCorrelationId.xml'>JavaScript.SetBackendCorrelationId</a></em>"]
@@ -309,7 +309,12 @@ flowchart
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.403Forbidden.xml'>RaiseFault.403Forbidden</a></em>"]
     403 --> E
-    Q6 --> |No| CN["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#content-negotiation'>Content Negotiation</a>"]
+    Q6 --> |No| Q6.1{Prefer 403.1 error?}
+    Q6.1 --> |Yes| 403.1["Raise 403 service ban error
+
+    <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.403ServiceBan.xml'>RaiseFault.403ServiceBan</a></em>"]
+    403.1 --> E
+    Q6.1 --> |No| CN["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#content-negotiation'>Content Negotiation</a>"]
     Q1 --> |No| VAT["Verify access token
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/OauthV2.VerifyAccessToken.xml'>OauthV2.VerifyAccessToken</a></em>"]
@@ -390,7 +395,7 @@ Source: [proxies/shared/partials/Partial.Target.PostFlow.xml](https://github.com
 
 ```mermaid
 flowchart LR
-    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#set-response-defaults'>Set response defaults</a>"]
+    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set response defaults</a>"]
     SRD --> E[End]
 ```
 
@@ -402,7 +407,7 @@ Source: [proxies/shared/partials/Partial.Target.FaultRules.xml](https://github.c
 
 ```mermaid
 flowchart
-    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/PROXIES.md#set-response-defaults'>Set response defaults</a>"]
+    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set response defaults</a>"]
     SRD --> Q1{Is sandbox environment?}
     Q1 --> |No| Q2{Token verification failure?}
     Q2 --> |Yes| 401["Raise 401 error
@@ -410,12 +415,17 @@ flowchart
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.401Unauthorized.xml'>RaiseFault.401Unauthorized</a></em>"]
     401 --> E1[End]
     Q2 --> |No| Q3{Backend 403 response?}
-    Q3 --> |Yes| 403["Raise 403 error
+    Q3 --> |Yes| Q3.1{Service ban?}
+    Q3.1 --> |Yes| 403ServiceBan["Raise 403 service ban error
+
+    <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.403ServiceBan.xml'>RaiseFault.403ServiceBan</a></em>"]
+    403ServiceBan --> E2[End]
+    Q3.1 --> |No| 403["Raise 403 error
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.403Forbidden.xml'>RaiseFault.403Forbidden</a></em>"]
     403 --> E2[End]
     Q3 --> |No| Q4{Backend 404 & invalid routing plan?}
-    Q1 --> |Yes| Q4
+    Q1 --> |Yes| Q3
     Q4 --> |Yes| 404Invalid["Raise 404 error
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.404InvalidRoutingPlan.xml'>RaiseFault.404InvalidRoutingPlan</a></em>"]

--- a/docs/tests/sandbox/index.md
+++ b/docs/tests/sandbox/index.md
@@ -12,3 +12,4 @@
   * [Invalid Routing Plans](post_v1_message-batches/invalid_routing_plans.md)
   * [Performance Tests](post_v1_message-batches/performance.md)
   * [Happy Path Tests](post_v1_message-batches/happy_path.md)
+  * [Service Ban](post_v1_message-batches/service_ban.md)

--- a/docs/tests/sandbox/post_v1_message-batches/index.md
+++ b/docs/tests/sandbox/post_v1_message-batches/index.md
@@ -4,3 +4,4 @@
 * [Invalid Routing Plans](invalid_routing_plans.md)
 * [Performance Tests](performance.md)
 * [Happy Path Tests](happy_path.md)
+* [Service Ban](service_ban.md)

--- a/docs/tests/sandbox/post_v1_message-batches/service_ban.md
+++ b/docs/tests/sandbox/post_v1_message-batches/service_ban.md
@@ -1,0 +1,49 @@
+# Service Ban
+
+
+### Scenario: An API consumer has been banned from the service,         when making requests they fail with a service ban response
+
+**Given** the API consumer has been banned
+<br/>
+**When** a request is submitted
+<br/>
+**Then** the response returns a 403 service ban error
+<br/>
+
+**Asserts**
+- Response returns a 403 ‘Service Ban’ error
+- Response returns the expected error message body referencing the Authorization header
+- Response returns the ‘X-Correlation-Id’ header if provided
+
+**Correlation IDs**
+
+This test uses the ‘X-Correlation-Id’ header, when provided in a request it is returned in the response.
+
+| Value                                | Description                                                                                                   |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| None                                 | Is tested to ensure that we do not send back a correlation identifier if one was not provided in the request. |
+| 76491414-d0cf-4655-ae20-a4d1368472f3 | Is tested to ensure that when a correlation identifier is sent, we respond with the same value.               |
+
+
+### Scenario: An API consumer wants to test the service ban         error message on the sandbox environment
+
+**Given** the API consumer provides a code 403.1 prefer header
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response returns a 403 service ban error
+<br/>
+
+**Asserts**
+- Response returns a 403 ‘Service Ban’ error
+- Response returns the expected error message body referencing the Authorization header
+- Response returns the ‘X-Correlation-Id’ header if provided
+
+**Correlation IDs**
+
+This test uses the ‘X-Correlation-Id’ header, when provided in a request it is returned in the response.
+
+| Value                                | Description                                                                                                   |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| None                                 | Is tested to ensure that we do not send back a correlation identifier if one was not provided in the request. |
+| 76491414-d0cf-4655-ae20-a4d1368472f3 | Is tested to ensure that when a correlation identifier is sent, we respond with the same value.               |

--- a/proxies/shared/partials/Partial.Flows.CreateMessageBatchEndpoint.xml
+++ b/proxies/shared/partials/Partial.Flows.CreateMessageBatchEndpoint.xml
@@ -14,9 +14,11 @@
         <Step>
             <Name>AssignMessage.MessageBatches.Create.Request</Name>
         </Step>
-        <Step>
-            <Name>AssignMessage.AuthenticationDetails</Name>
-        </Step>
+        {% if ENVIRONMENT_TYPE != 'sandbox' %}
+            <Step>
+                <Name>AssignMessage.AuthenticationDetails</Name>
+            </Step>
+        {% endif %}
     </Request>
     <Response>
         <Step>

--- a/proxies/shared/partials/Partial.Flows.RateLimiting.xml
+++ b/proxies/shared/partials/Partial.Flows.RateLimiting.xml
@@ -1,6 +1,6 @@
 <Flow name="RateLimiting">
     <Request>
-      {% if ENVIRONMENT_TYPE != 'sandbox' %}
+        {% if ENVIRONMENT_TYPE != 'sandbox' %}
             <Step>
                 <Name>SpikeArrest.PerApp</Name>
             </Step>

--- a/proxies/shared/partials/Partial.Target.FaultRules.xml
+++ b/proxies/shared/partials/Partial.Target.FaultRules.xml
@@ -7,11 +7,15 @@
                 oauthV2.OauthV2.VerifyAccessToken.failed = true or fault.name = "access_token_expired" or fault.name = "invalid_access_token" or fault.name = "InvalidAccessToken" or fault.name = "access_token_not_approved" or fault.name = "apiresource_doesnot_exist" or fault.name = "InvalidAPICallAsNo" or fault.name = "ApiProductMatchFound"
             </Condition>
         </Step>
-        <Step>
-            <Name>RaiseFault.403Forbidden</Name>
-            <Condition>response.status.code = 403</Condition>
-        </Step>
     {% endif %}
+    <Step>
+        <Name>RaiseFault.403ServiceBan</Name>
+        <Condition>response.status.code = 403 and response.content like "*Request rejected because client service ban is in effect*"</Condition>
+    </Step>
+    <Step>
+        <Name>RaiseFault.403Forbidden</Name>
+        <Condition>response.status.code = 403</Condition>
+    </Step>
     <Step>
         <Name>RaiseFault.404InvalidRoutingPlan</Name>
         <Condition>

--- a/proxies/shared/partials/Partial.Target.PreFlowRequest.xml
+++ b/proxies/shared/partials/Partial.Target.PreFlowRequest.xml
@@ -30,6 +30,12 @@
         request.header.Authorization = "Bearer ClientNotRecognised" or request.header.Prefer = "code=403"
       </Condition>
     </Step>
+    <Step>
+      <Name>RaiseFault.403ServiceBan</Name>
+      <Condition>
+        request.header.Prefer = "code=403.1"
+      </Condition>
+    </Step>
 {% else %}
     <Step>
         <Name>OauthV2.VerifyAccessToken</Name>

--- a/proxies/shared/policies/RaiseFault.403ServiceBan.xml
+++ b/proxies/shared/policies/RaiseFault.403ServiceBan.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ This policy raises a 403 error response due to there being a service ban in place on the consumers account.
+
+ Raisefault policies stop the execution of the current flow and move to the error flow, which returns the error response defined here to the requesting application.
+
+ For more information on RaiseFault policies within Apigee see the following resource:
+    * https://docs.apigee.com/api-platform/reference/policies/raise-fault-policy
+-->
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.403ServiceBan">
+    <DisplayName>RaiseFault.403ServiceBan</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>403</StatusCode>
+            <ReasonPhrase>Forbidden</ReasonPhrase>
+            <Payload variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "@messageid#.0",
+                            "code" : "CM_SERVICE_BAN",
+                            "links" : {
+                                "about" : "{{ ERROR_ABOUT_LINK }}"
+                            },
+                            "status" : "403",
+                            "title" : "Service ban in effect",
+                            "detail" : "A service ban is in effect on your account.",
+                            "source" : {
+                                "header" : "Authorization"
+                            }
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/sandbox/app.spec.js
+++ b/sandbox/app.spec.js
@@ -1,4 +1,3 @@
-
 const request = require("supertest");
 const assert = require("chai").assert;
 
@@ -57,6 +56,16 @@ describe("app handler tests", function () {
     });
 
     describe('/api/v1/send', () => {
+        it('returns a service ban (403) when the user is banned', (done) => {
+            request(server)
+                .post('/api/v1/send')
+                .set({ Authorization: 'banned' })
+                .expect(403, {
+                    message: 'Request rejected because client service ban is in effect'
+                })
+                .expect("Content-Type", /json/, done);
+        });
+
         it('returns a 400 when body doesnt exist', (done) => {
             request(server)
                 .post('/api/v1/send')

--- a/sandbox/handlers.js
+++ b/sandbox/handlers.js
@@ -93,6 +93,12 @@ const duplicateTemplates = [
 ];
 
 async function batch_send(req, res, next) {
+    if (req.headers["authorization"] === "banned") {
+        sendError(res, 403, "Request rejected because client service ban is in effect");
+        next();
+        return;
+    }
+
     if (!req.body) {
         sendError(res, 400, "Missing request body");
         next();

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -318,18 +318,31 @@ paths:
           description: |+
             Your request contained an authentic bearer token in the `Authorization` header but you are not authorized to make the request.
 
-            This is due the onboarding process not having been completed. Refer to our [onboarding](#overview--onboarding) section for more information.
+            If the error code in the response is `CM_FORBIDDEN` then this could be due to the onboarding process not having been completed. Refer to our [onboarding](#overview--onboarding) section for more information.
+
+            If the response contains the error `CM_SERVICE_BAN` then there is a ban in effect on your account.
 
             ### Sandbox
 
-            It is possible to trigger this error in the sandbox by sending the header `Prefer` with a value of `code=403`.
+            It is possible to trigger the `CM_FORBIDDEN` error in the sandbox by sending the header `Prefer` with a value of `code=403`.
 
-            Here is an example curl request to trigger a `403`:
+            Here is an example curl request to trigger a `CM_FORBIDDEN`:
 
             ```
               curl -X GET \
                 --header "Accept: */*" \
                 --header "Prefer: code=403" \
+                https://sandbox.api.service.nhs.uk/comms/
+            ```
+
+            To trigger the `CM_SERVICE_BAN` error in the sandbox by sending the header `Prefer` with a value of `code=403.1`.
+
+            Here is an example curl request to trigger a `CM_FORBIDDEN`:
+
+            ```
+              curl -X GET \
+                --header "Accept: */*" \
+                --header "Prefer: code=403.1" \
                 https://sandbox.api.service.nhs.uk/comms/
             ```
           content:

--- a/specification/schemas/ForbiddenResponse.yaml
+++ b/specification/schemas/ForbiddenResponse.yaml
@@ -25,11 +25,13 @@ properties:
           type: string
           enum:
             - Forbidden
+            - Service ban in effect
           example: Forbidden
         detail:
           type: string
           enum:
             - Client not recognised or not yet onboarded.
+            - A service ban is in effect on your account.
           example: Client not recognised or not yet onboarded.
         source:
           type: object

--- a/specification/schemas/enums/EnumErrorForbidden.yaml
+++ b/specification/schemas/enums/EnumErrorForbidden.yaml
@@ -1,5 +1,6 @@
 type: string
 enum:
   - CM_FORBIDDEN
+  - CM_SERVICE_BAN
 example: CM_FORBIDDEN
 title: Enum_Error_Forbidden

--- a/tests/docs/sandbox/post_v1_message-batches/index.rst
+++ b/tests/docs/sandbox/post_v1_message-batches/index.rst
@@ -8,3 +8,4 @@ POST /v1/message-batches
    invalid_routing_plans
    performance
    happy_path
+   service_ban

--- a/tests/docs/sandbox/post_v1_message-batches/service_ban.rst
+++ b/tests/docs/sandbox/post_v1_message-batches/service_ban.rst
@@ -1,0 +1,6 @@
+Service Ban
+===========
+
+.. automodule:: sandbox.create_message_batches.test_service_ban
+    :noindex:
+    :members:

--- a/tests/lib/constants.py
+++ b/tests/lib/constants.py
@@ -144,6 +144,14 @@ ERROR_FORBIDDEN = Error(
     "Client not recognised or not yet onboarded."
 )
 
+# service ban
+ERROR_SERVICE_BAN = Error(
+    "CM_SERVICE_BAN",
+    "403",
+    "Service ban in effect",
+    "A service ban is in effect on your account."
+)
+
 # not acceptable
 ERROR_NOT_ACCEPTABLE = Error(
     "CM_NOT_ACCEPTABLE",

--- a/tests/lib/generators.py
+++ b/tests/lib/generators.py
@@ -83,6 +83,12 @@ class Generators():
         })
 
     @staticmethod
+    def generate_service_ban_error():
+        return Generators.generate_error(constants.ERROR_SERVICE_BAN, source={
+            "header": "Authorization"
+        })
+
+    @staticmethod
     def generate_not_acceptable_error():
         return Generators.generate_error(constants.ERROR_NOT_ACCEPTABLE, source={
             "header": "Accept"

--- a/tests/sandbox/authentication/test_401_errors.py
+++ b/tests/sandbox/authentication/test_401_errors.py
@@ -1,7 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators
-from lib.constants import *
+from lib.constants import CORRELATION_IDS, METHODS
 
 
 MOCK_TOKEN = {

--- a/tests/sandbox/authentication/test_403_errors.py
+++ b/tests/sandbox/authentication/test_403_errors.py
@@ -1,12 +1,11 @@
 import requests
 import pytest
 from lib import Assertions, Generators
+from lib.constants import METHODS, CORRELATION_IDS
 
 FORBIDDEN_TOKEN = {
     "Authorization": "Bearer ClientNotRecognised"
 }
-METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
-CORRELATION_IDS = [None, "76491414-d0cf-4655-ae20-a4d1368472f3"]
 
 
 @pytest.mark.sandboxtest

--- a/tests/sandbox/create_message_batches/test_service_ban.py
+++ b/tests/sandbox/create_message_batches/test_service_ban.py
@@ -1,0 +1,84 @@
+import requests
+import pytest
+from lib import Assertions, Generators
+from lib.constants import CORRELATION_IDS
+
+FORBIDDEN_TOKEN = {
+    "Authorization": "Bearer ClientNotRecognised"
+}
+
+
+@pytest.mark.sandboxtest
+@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+def test_403_service_ban(nhsd_apim_proxy_url, correlation_id):
+    """
+    .. py:function:: Scenario: An API consumer has been banned from the service, \
+        when making requests they fail with a service ban response
+
+        | **Given** the API consumer has been banned
+        | **When** a request is submitted
+        | **Then** the response returns a 403 service ban error
+
+    **Asserts**
+    - Response returns a 403 'Service Ban' error
+    - Response returns the expected error message body referencing the Authorization header
+    - Response returns the 'X-Correlation-Id' header if provided
+
+    .. include:: ../../partials/correlation_ids.rst
+    """
+
+    resp = requests.post(
+        f"{nhsd_apim_proxy_url}/v1/message-batches",
+        headers={
+            "Authorization": "banned",
+            "Content-Type": "application/json",
+            "X-Correlation-Id": correlation_id,
+            "Accept": "*/*"
+        },
+        json=Generators.generate_valid_create_message_batch_body("sandbox")
+    )
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        403,
+        Generators.generate_service_ban_error(),
+        correlation_id
+    )
+
+
+@pytest.mark.sandboxtest
+@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+def test_prefer_403_service_ban(nhsd_apim_proxy_url, correlation_id):
+    """
+    .. py:function:: Scenario: An API consumer wants to test the service ban \
+        error message on the sandbox environment
+
+        | **Given** the API consumer provides a code 403.1 prefer header
+        | **When** the request is submitted
+        | **Then** the response returns a 403 service ban error
+
+    **Asserts**
+    - Response returns a 403 'Service Ban' error
+    - Response returns the expected error message body referencing the Authorization header
+    - Response returns the 'X-Correlation-Id' header if provided
+
+    .. include:: ../../partials/correlation_ids.rst
+    """
+
+    resp = requests.post(
+        f"{nhsd_apim_proxy_url}/v1/message-batches",
+        headers={
+            "Prefer": "code=403.1",
+            "Content-Type": "application/json",
+            "X-Correlation-Id": correlation_id,
+            "Accept": "*/*"
+        },
+        json=Generators.generate_valid_create_message_batch_body("sandbox")
+    )
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        403,
+        Generators.generate_service_ban_error(),
+        correlation_id
+    )


### PR DESCRIPTION
## Summary

Adds a new policy that allows for service ban responses from the backend solution to trigger a custom 403 response within the API proxy.

Ensures that the sandbox mock application can throw errors in the same way as the backend application, with test coverage over it and the policy being run.

Updates the documentation for the proxy to include the new logic around the handling of 403 & 403 service bans.

Adds the 403 service ban information to the API specification.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
