### PR TITLE
CCM-2152: Remove aws headers from responses

### DIFF
--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -21,9 +21,10 @@ context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 // remove aws headers
 const headers = context.getVariable("response.header");
 const headerRegex = /^x-amz-/;
-Object.keys(headers).forEach(function (headerKey) {
-  if (headerRegex.test(headerKey.toLowerCase())) {
-    context.removeVariable("response.header." + headerKey);
+headers.forEach(header => {
+  if (headerRegex.test(header.key.toLowerCase())) {
+    context.removeVariable("response.header." + header.key);
+    context.removeVariable("error.header." + header.key);
   }
 });
 

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -21,12 +21,12 @@ context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 // remove aws headers
 const headers = context.getVariable("response.header");
 const headerRegex = /^x-amz-/;
-headers.forEach(function (header)  {
+for (let header of headers) {
   if (headerRegex.test(header.key.toLowerCase())) {
     context.removeVariable("response.header." + header.key);
     context.removeVariable("error.header." + header.key);
   }
-});
+};
 
 // format errors and response objects
 try {

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -21,7 +21,7 @@ context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 // remove aws headers
 const headers = context.getVariable("response.header");
 const headerRegex = /^x-amz-/;
-headers.forEach(header => {
+headers.forEach(function (header)  {
   if (headerRegex.test(header.key.toLowerCase())) {
     context.removeVariable("response.header." + header.key);
     context.removeVariable("error.header." + header.key);

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -19,7 +19,6 @@ context.setVariable("response.header.X-Content-Type-Options", "nosniff");
 context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 
 // remove aws headers
-
 const headerNames = (context.getVariable("response.headers.names") + "").slice(1, -1).split(', ');
 const headerRegex = /^x-amz/;
 headerNames.forEach(function (header)  {

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -19,12 +19,12 @@ context.setVariable("response.header.X-Content-Type-Options", "nosniff");
 context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 
 // remove aws headers
-const headers = context.getVariable("response.headers");
+const headerNames = (context.getVariable("request.headers.names") + "").slice(1, -1).split(', ');
 const headerRegex = /^x-amz-/;
-headers.forEach(function (header)  {
-  if (headerRegex.test(header.key.toLowerCase())) {
-    context.removeVariable("response.header." + header.key);
-    context.removeVariable("error.header." + header.key);
+headerNames.forEach(function (header)  {
+  if (headerRegex.test(header.toLowerCase())) {
+    context.removeVariable("response.header." + header);
+    context.removeVariable("error.header." + header);
   }
 });
 

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -19,14 +19,14 @@ context.setVariable("response.header.X-Content-Type-Options", "nosniff");
 context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 
 // remove aws headers
-const headers = context.getVariable("response.header");
+const headers = context.getVariable("response.headers");
 const headerRegex = /^x-amz-/;
-for (let header of headers) {
+headers.forEach(function (header)  {
   if (headerRegex.test(header.key.toLowerCase())) {
     context.removeVariable("response.header." + header.key);
     context.removeVariable("error.header." + header.key);
   }
-};
+});
 
 // format errors and response objects
 try {

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -18,6 +18,15 @@ context.setVariable("error.header.Cache-Control", "no-cache, no-store, must-reva
 context.setVariable("response.header.X-Content-Type-Options", "nosniff");
 context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 
+// remove aws headers
+const headers = context.getVariable("response.header");
+const headerRegex = /^x-amz-/;
+Object.keys(headers).forEach(function (headerKey) {
+  if (headerRegex.test(headerKey.toLowerCase())) {
+    context.removeVariable("response.header." + headerKey);
+  }
+});
+
 // format errors and response objects
 try {
   const errorContent = context.getVariable("error.content")

--- a/proxies/shared/resources/jsc/SetResponseDefaults.js
+++ b/proxies/shared/resources/jsc/SetResponseDefaults.js
@@ -19,8 +19,9 @@ context.setVariable("response.header.X-Content-Type-Options", "nosniff");
 context.setVariable("error.header.X-Content-Type-Options", "nosniff");
 
 // remove aws headers
-const headerNames = (context.getVariable("request.headers.names") + "").slice(1, -1).split(', ');
-const headerRegex = /^x-amz-/;
+
+const headerNames = (context.getVariable("response.headers.names") + "").slice(1, -1).split(', ');
+const headerRegex = /^x-amz/;
 headerNames.forEach(function (header)  {
   if (headerRegex.test(header.toLowerCase())) {
     context.removeVariable("response.header." + header);

--- a/tests/development/headers/test_x_amz_removal.py
+++ b/tests/development/headers/test_x_amz_removal.py
@@ -1,0 +1,21 @@
+import requests
+import pytest
+
+from lib import Assertions
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, TEST_METHODS
+
+
+@pytest.mark.devtest
+@pytest.mark.parametrize("method", TEST_METHODS)
+@pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
+@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
+def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method, nhsd_apim_auth_headers,):
+
+    resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
+        **nhsd_apim_auth_headers,
+        "Accept": "*/*",
+        "Origin": ORIGIN,
+        "Access-Control-Request-Method": method
+    })
+
+    Assertions.assert_no_aws_headers(resp)

--- a/tests/development/headers/test_x_amz_removal.py
+++ b/tests/development/headers/test_x_amz_removal.py
@@ -2,11 +2,11 @@ import requests
 import pytest
 
 from lib import Assertions
-from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, TEST_METHODS
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS
 
 
 @pytest.mark.devtest
-@pytest.mark.parametrize("method", TEST_METHODS)
+@pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 @pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method, nhsd_apim_auth_headers,):

--- a/tests/integration/headers/test_cors.py
+++ b/tests/integration/headers/test_cors.py
@@ -1,8 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Authentication
-from lib.constants.constants import INT_URL, VALID_ENDPOINTS
-
+from lib.constants.constants import INT_URL, VALID_ENDPOINTS, ORIGIN
 
 METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 TEST_METHODS = ["get", "post", "put", "delete"]
@@ -18,7 +17,7 @@ def test_cors_options(method, endpoints):
     resp = requests.options(f"{INT_URL}{endpoints}", headers={
         "Authorization": f"{Authentication.generate_authentication('int')}",
         "Accept": "*/*",
-        "Origin": "https://my.website",
+        "Origin": ORIGIN,
         "Access-Control-Request-Method": method
     })
     Assertions.assert_cors_response(resp, "https://my.website")
@@ -34,7 +33,7 @@ def test_cors(method, endpoints):
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
         "Authorization": f"{Authentication.generate_authentication('int')}",
         "Accept": "*/*",
-        "Origin": "https://my.website"
+        "Origin": ORIGIN
     })
 
     Assertions.assert_cors_headers(resp, "https://my.website")

--- a/tests/integration/headers/test_x_amz_removal.py
+++ b/tests/integration/headers/test_x_amz_removal.py
@@ -1,18 +1,20 @@
 import requests
 import pytest
 
-from lib import Assertions
-from lib.constants.constants import VALID_ENDPOINTS, TEST_METHODS
+from lib import Assertions, Authentication
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, TEST_METHODS
 
 
-@pytest.mark.sandboxtest
+@pytest.mark.inttest
 @pytest.mark.parametrize("method", TEST_METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
+        "Authorization": f"{Authentication.generate_authentication('int')}",
         "Accept": "*/*",
-        "Origin": "https://my.website"
+        "Origin": ORIGIN,
+        "Access-Control-Request-Method": method
     })
 
     Assertions.assert_no_aws_headers(resp)

--- a/tests/integration/headers/test_x_amz_removal.py
+++ b/tests/integration/headers/test_x_amz_removal.py
@@ -2,11 +2,11 @@ import requests
 import pytest
 
 from lib import Assertions, Authentication
-from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, TEST_METHODS
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS
 
 
 @pytest.mark.inttest
-@pytest.mark.parametrize("method", TEST_METHODS)
+@pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -215,3 +215,9 @@ class Assertions():
         assert resp.headers.get("Access-Control-Allow-Origin") == website
         assert resp.headers.get("Access-Control-Expose-Headers") == CORS_EXPOSE_HEADERS
         assert resp.headers.get("Cross-Origin-Resource-Policy") == CORS_POLICY
+
+    @staticmethod
+    def assert_no_aws_headers(resp):
+        assert "X-Amzn-Trace-Id" not in resp.headers
+        assert "x-amzn-RequestId" not in resp.headers
+        assert "x-amz-apigw-id" not in resp.headers

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -26,7 +26,9 @@ MISSING_TEMPLATE_ROUTING_PLANS = [
 
 TOKENS = [None, "Bearer xyzcba", "Bearer", "junk"]
 METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
+TEST_METHODS = ["get", "post", "put", "delete"]
 CORRELATION_IDS = [None, "76491414-d0cf-4655-ae20-a4d1368472f3"]
+ORIGIN = "https://my.website"
 NUM_MAX_ERRORS = 100
 DEV_API_GATEWAY_URL = "https://comms-apim.internal-dev.communications.national.nhs.uk"
 INT_API_GATEWAY_URL = "https://comms-apim.int.communications.national.nhs.uk"

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -26,7 +26,6 @@ MISSING_TEMPLATE_ROUTING_PLANS = [
 
 TOKENS = [None, "Bearer xyzcba", "Bearer", "junk"]
 METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
-TEST_METHODS = ["get", "post", "put", "delete"]
 CORRELATION_IDS = [None, "76491414-d0cf-4655-ae20-a4d1368472f3"]
 ORIGIN = "https://my.website"
 NUM_MAX_ERRORS = 100

--- a/tests/production/headers/test_cors.py
+++ b/tests/production/headers/test_cors.py
@@ -1,8 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Authentication
-from lib.constants.constants import PROD_URL, VALID_ENDPOINTS
-
+from lib.constants.constants import PROD_URL, VALID_ENDPOINTS, ORIGIN
 
 METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 TEST_METHODS = ["get", "post", "put", "delete"]
@@ -18,7 +17,7 @@ def test_cors_options(method, endpoints):
     resp = requests.options(f"{PROD_URL}{endpoints}", headers={
         "Authorization": f"{Authentication.generate_authentication('prod')}",
         "Accept": "*/*",
-        "Origin": "https://my.website",
+        "Origin": ORIGIN,
         "Access-Control-Request-Method": method
     })
     Assertions.assert_cors_response(resp, "https://my.website")
@@ -34,7 +33,7 @@ def test_cors(method, endpoints):
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
         "Authorization": f"{Authentication.generate_authentication('prod')}",
         "Accept": "*/*",
-        "Origin": "https://my.website"
+        "Origin": ORIGIN
     })
 
     Assertions.assert_cors_headers(resp, "https://my.website")

--- a/tests/production/headers/test_x_amz_removal.py
+++ b/tests/production/headers/test_x_amz_removal.py
@@ -1,18 +1,20 @@
 import requests
 import pytest
 
-from lib import Assertions
-from lib.constants.constants import VALID_ENDPOINTS, TEST_METHODS
+from lib import Assertions, Authentication
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, TEST_METHODS
 
 
-@pytest.mark.sandboxtest
+@pytest.mark.prodtest
 @pytest.mark.parametrize("method", TEST_METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
+        "Authorization": f"{Authentication.generate_authentication('prod')}",
         "Accept": "*/*",
-        "Origin": "https://my.website"
+        "Origin": ORIGIN,
+        "Access-Control-Request-Method": method
     })
 
     Assertions.assert_no_aws_headers(resp)

--- a/tests/production/headers/test_x_amz_removal.py
+++ b/tests/production/headers/test_x_amz_removal.py
@@ -2,11 +2,11 @@ import requests
 import pytest
 
 from lib import Assertions, Authentication
-from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, TEST_METHODS
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS
 
 
 @pytest.mark.prodtest
-@pytest.mark.parametrize("method", TEST_METHODS)
+@pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 

--- a/tests/sandbox/headers/test_cors.py
+++ b/tests/sandbox/headers/test_cors.py
@@ -1,8 +1,7 @@
 import requests
 import pytest
 from lib import Assertions
-from lib.constants.constants import VALID_ENDPOINTS
-
+from lib.constants.constants import VALID_ENDPOINTS, ORIGIN
 
 METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 TEST_METHODS = ["get", "post", "put", "delete"]
@@ -17,7 +16,7 @@ def test_cors_options(nhsd_apim_proxy_url, method, endpoints):
     """
     resp = requests.options(f"{nhsd_apim_proxy_url}{endpoints}", headers={
         "Accept": "*/*",
-        "Origin": "https://my.website",
+        "Origin": ORIGIN,
         "Access-Control-Request-Method": method
     })
     Assertions.assert_cors_response(resp, "https://my.website")
@@ -32,7 +31,7 @@ def test_cors(nhsd_apim_proxy_url, method, endpoints):
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
         "Accept": "*/*",
-        "Origin": "https://my.website"
+        "Origin": ORIGIN
     })
 
     Assertions.assert_cors_headers(resp, "https://my.website")

--- a/tests/sandbox/headers/test_x_amz_removal.py
+++ b/tests/sandbox/headers/test_x_amz_removal.py
@@ -1,0 +1,20 @@
+import requests
+import pytest
+
+from lib import Assertions
+from lib.constants.constants import VALID_ENDPOINTS
+
+TEST_METHODS = ["get", "post", "put", "delete"]
+
+
+@pytest.mark.sandboxtest
+@pytest.mark.parametrize("method", TEST_METHODS)
+@pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
+def test_request_with_x_amz_is_removed( nhsd_apim_proxy_url, endpoints, method):
+
+    resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
+        "Accept": "*/*",
+        "Origin": "https://my.website"
+    })
+
+    Assertions.assert_no_aws_headers(resp)

--- a/tests/sandbox/headers/test_x_amz_removal.py
+++ b/tests/sandbox/headers/test_x_amz_removal.py
@@ -2,7 +2,7 @@ import requests
 import pytest
 
 from lib import Assertions
-from lib.constants.constants import VALID_ENDPOINTS, TEST_METHODS
+from lib.constants.constants import VALID_ENDPOINTS, TEST_METHODS, ORIGIN
 
 
 @pytest.mark.sandboxtest
@@ -12,7 +12,7 @@ def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
         "Accept": "*/*",
-        "Origin": "https://my.website"
+        "Origin": ORIGIN
     })
 
     Assertions.assert_no_aws_headers(resp)

--- a/tests/sandbox/headers/test_x_amz_removal.py
+++ b/tests/sandbox/headers/test_x_amz_removal.py
@@ -10,7 +10,7 @@ TEST_METHODS = ["get", "post", "put", "delete"]
 @pytest.mark.sandboxtest
 @pytest.mark.parametrize("method", TEST_METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_request_with_x_amz_is_removed( nhsd_apim_proxy_url, endpoints, method):
+def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
         "Accept": "*/*",

--- a/tests/sandbox/headers/test_x_amz_removal.py
+++ b/tests/sandbox/headers/test_x_amz_removal.py
@@ -2,11 +2,11 @@ import requests
 import pytest
 
 from lib import Assertions
-from lib.constants.constants import VALID_ENDPOINTS, TEST_METHODS, ORIGIN
+from lib.constants.constants import VALID_ENDPOINTS, METHODS, ORIGIN
 
 
 @pytest.mark.sandboxtest
-@pytest.mark.parametrize("method", TEST_METHODS)
+@pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
 


### PR DESCRIPTION
## Summary
This work aims to remove amazon headers from the response, Ive taken a regex approach to pattern match on x-amz. I have extended the testing assertion library to assert on 3 different types on headers which also covers the majority of edge cases e.g. casing and amzn type headers.


## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] Branch deployed to a dynamic env - link to deployment pipeline
* [ ] PR link shared on Slack and/or Teams
* [ ] 1 reviews received
