### PR TITLE
WIP: CCM-2141 429s to include default response headers

### DIFF
--- a/proxies/shared/partials/Partial.Headers.CorsHeaders.xml
+++ b/proxies/shared/partials/Partial.Headers.CorsHeaders.xml
@@ -1,0 +1,5 @@
+<Header name="Access-Control-Allow-Origin">{request.header.origin}</Header>
+<Header name="Access-Control-Allow-Headers">origin, x-requested-with, accept, content-type, nhsd-session-urid, x-correlation-id, authorization</Header>
+<Header name="Access-Control-Max-Age">3628800</Header>
+<Header name="Access-Control-Allow-Methods">GET, PUT, POST, PATCH, DELETE</Header>
+<Header name="Cross-Origin-Resource-Policy">cross-origin</Header>

--- a/proxies/shared/policies/AssignMessage.AddCors.xml
+++ b/proxies/shared/policies/AssignMessage.AddCors.xml
@@ -13,11 +13,7 @@
     <Properties/>
     <Set>
         <Headers>
-            <Header name="Access-Control-Allow-Origin">{request.header.origin}</Header>
-            <Header name="Access-Control-Allow-Headers">origin, x-requested-with, accept, content-type, nhsd-session-urid, x-correlation-id, authorization</Header>
-            <Header name="Access-Control-Max-Age">3628800</Header>
-            <Header name="Access-Control-Allow-Methods">GET, PUT, POST, PATCH, DELETE</Header>
-            <Header name="Cross-Origin-Resource-Policy">cross-origin</Header>
+            [% include './partials/Partial.Headers.CorsHeaders.xml' %]
         </Headers>
     </Set>
     <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>

--- a/proxies/shared/policies/Quota.Global.xml
+++ b/proxies/shared/policies/Quota.Global.xml
@@ -12,7 +12,7 @@ For more information on rate limiting, see the following resources:
     <DisplayName>Quota.Global</DisplayName>
     <Interval>1</Interval>
     <TimeUnit>minute</TimeUnit>
-    <Allow count="6000"/>
+    <Allow count="5"/>
     <AsynchronousConfiguration>
         <SyncMessageCount>100</SyncMessageCount>
     </AsynchronousConfiguration>

--- a/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
+++ b/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
@@ -45,5 +45,5 @@
             </Payload>
         </Set>
     </FaultResponse>
-    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
 </RaiseFault>

--- a/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
+++ b/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
@@ -14,7 +14,7 @@
     <DisplayName>RaiseFault.429TooManyRequests</DisplayName>
     <Properties/>
     <FaultResponse>
-        <Set>
+      <!--        <Add>
             {% if ENVIRONMENT_TYPE == 'sandbox' %}
                 <Headers>
                     <Header name="Retry-After">5</Header>
@@ -22,6 +22,8 @@
             {% else %}
                 <Headers/>
             {% endif %}
+      </Add> -->
+        <Set>
             <StatusCode>429</StatusCode>
             <ReasonPhrase>Too many requests</ReasonPhrase>
             <Payload variablePrefix="@" variableSuffix="#">

--- a/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
+++ b/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
@@ -18,11 +18,8 @@
             {% if ENVIRONMENT_TYPE == 'sandbox' %}
                 <Headers>
                     <Header name="Retry-After">5</Header>
-                    [% include './partials/Partial.Headers.CorsHeaders.xml' %]
                 </Headers>
             {% else %}
-                <Headers>
-                    [% include './partials/Partial.Headers.CorsHeaders.xml' %]
                 <Headers/>
             {% endif %}
             <StatusCode>429</StatusCode>

--- a/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
+++ b/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
@@ -17,9 +17,12 @@
         <Set>
             {% if ENVIRONMENT_TYPE == 'sandbox' %}
                 <Headers>
+                    [% include './partials/Partial.Headers.CorsHeaders.xml' %]
                     <Header name="Retry-After">5</Header>
                 </Headers>
             {% else %}
+                <Headers>
+                    [% include './partials/Partial.Headers.CorsHeaders.xml' %]
                 <Headers/>
             {% endif %}
             <StatusCode>429</StatusCode>

--- a/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
+++ b/proxies/shared/policies/RaiseFault.429TooManyRequests.xml
@@ -14,16 +14,17 @@
     <DisplayName>RaiseFault.429TooManyRequests</DisplayName>
     <Properties/>
     <FaultResponse>
-      <!--        <Add>
+        <Set>
             {% if ENVIRONMENT_TYPE == 'sandbox' %}
                 <Headers>
                     <Header name="Retry-After">5</Header>
+                    [% include './partials/Partial.Headers.CorsHeaders.xml' %]
                 </Headers>
             {% else %}
+                <Headers>
+                    [% include './partials/Partial.Headers.CorsHeaders.xml' %]
                 <Headers/>
             {% endif %}
-      </Add> -->
-        <Set>
             <StatusCode>429</StatusCode>
             <ReasonPhrase>Too many requests</ReasonPhrase>
             <Payload variablePrefix="@" variableSuffix="#">


### PR DESCRIPTION
## Summary

This moves the CORS headers into a separate file and includes them from two places (to save duplicating them) so that the 429 response also includes the same headers. We found we had to set `IgnoreUnresolvedVariables` to `true` in the 429 fault to allow apigee to handle an unspecified origin as it did before, otherwise the API throws a 500 internal server error when it would otherwise throw a 429 but no origin is specified.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] Branch deployed to a dynamic env - link to deployment pipeline
* [ ] PR link shared on Slack and/or Teams
* [ ] 1 reviews received
