### PR TITLE
CCM-2327

### DIFF
--- a/specification/schemas/responses/MessageBatch.yaml
+++ b/specification/schemas/responses/MessageBatch.yaml
@@ -20,3 +20,6 @@ properties:
             description: Your unique message batch reference, provided within the payload to create the batch of messages.
             format: uuid
             example: da0b1495-c7cb-468c-9d81-07dee089d728
+          routingPlan:
+            description: The routing plan that you requested the messages be sent with.
+            $ref: ../types/RoutingPlan.yaml


### PR DESCRIPTION
## Summary

Adds routing plan field onto the docs for the create message batch endpoint:

![image](https://github.com/NHSDigital/communications-manager-api/assets/879532/a0a1a166-b1d1-4806-968b-f4631c290f5f)

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] Branch deployed to a dynamic env - link to deployment pipeline
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
