### PR TITLE
CCM-2970 AMP-2407 rename comms mgr api to nhs notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "author": "NHS Digital",
   "license": "MIT",
-  "homepage": "https://digital.nhs.uk/developer/api-catalogue/communications-manager",
+  "homepage": "https://digital.nhs.uk/developer/api-catalogue/nhs-notify",
   "bugs": {
     "url": "https://github.com/NHSDigital/communications-manager-api/issues"
   },

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   version: '3.0'
-  title: Communications Manager API
+  title: NHS Notify API
   description:
     $ref: documentation/APIDescription.md
   contact:

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -5,7 +5,7 @@ info:
   description:
     $ref: documentation/APIDescription.md
   contact:
-    name: Communications Manager Service API Support
+    name: NHS Notify API Support
     url: 'https://digital.nhs.uk/developer/help-and-support'
     email: api.management@nhs.net
 servers:

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -2,18 +2,18 @@
 
 Use this API to send messages to citizens via email, SMS, the NHS App or letter.
 
-Communications Manager provides:
+NHS Notify provides:
 
 * message templating
 * message routing - via SMS, email, letter and NHS App
 * enrichment of recipient details
 * support for accessible formats and multiple languages
 
-For more information about this services capabilities, see [Communications Manager Service](https://digital.nhs.uk/services/communications-manager).
+For more information about this services capabilities, see [NHS Notify](https://digital.nhs.uk/services/nhs-notify).
 
 ## Who can use this API
 
-The Communications Manager service is intended for services involved in direct care. This API can only be used where you have a legal basis to issue communications to citizens.
+The NHS Notify service is intended for services involved in direct care. This API can only be used where you have a legal basis to issue communications to citizens.
 
 ## API status and roadmap
 
@@ -126,7 +126,7 @@ Rather, use the [production test patient for PDS](https://digital.nhs.uk/develop
 
 ## Onboarding
 
-You need to get your software approved by us before it can go live with this API. You will also need to undertake the Communications Manager onboarding process which is still being defined. Further details will follow.
+You need to get your software approved by us before it can go live with this API. You will also need to undertake the NHS Notify onboarding process which is still being defined. Further details will follow.
 
 To understand how our online digital onboarding process works, see [digital onboarding](https://digital.nhs.uk/developer/guides-and-documentation/digital-onboarding).
 

--- a/specification/documentation/CreateMessage.md
+++ b/specification/documentation/CreateMessage.md
@@ -28,7 +28,7 @@ When sending this request on sandbox you must use one of the 5 preconfigured rou
 * `936e9d45-15de-4a95-bb36-ae163c33ae53`
 * `9ba00d23-cd6f-4aca-8688-00abc85a7980`
 
-On other environments these values will be established as part of your [NHS Notify service onboarding](#overview--onboarding).
+On other environments these values will be established as part of your [NHS Notify onboarding](#overview--onboarding).
 
 Here is an example curl request which creates a message using one of these routing plan identifiers:
 

--- a/specification/documentation/CreateMessage.md
+++ b/specification/documentation/CreateMessage.md
@@ -28,7 +28,7 @@ When sending this request on sandbox you must use one of the 5 preconfigured rou
 * `936e9d45-15de-4a95-bb36-ae163c33ae53`
 * `9ba00d23-cd6f-4aca-8688-00abc85a7980`
 
-On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+On other environments these values will be established as part of your [NHS Notify service onboarding](#overview--onboarding).
 
 Here is an example curl request which creates a message using one of these routing plan identifiers:
 

--- a/specification/documentation/CreateMessageBatch.md
+++ b/specification/documentation/CreateMessageBatch.md
@@ -33,7 +33,7 @@ When sending this request on sandbox you must use one of the 5 preconfigured rou
 * `936e9d45-15de-4a95-bb36-ae163c33ae53`
 * `9ba00d23-cd6f-4aca-8688-00abc85a7980`
 
-On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+On other environments these values will be established as part of your [NHS Notify service onboarding](#overview--onboarding).
 
 Here is an example curl request which creates a message batch using one of these routing plan identifiers:
 

--- a/specification/documentation/CreateMessageBatch.md
+++ b/specification/documentation/CreateMessageBatch.md
@@ -33,7 +33,7 @@ When sending this request on sandbox you must use one of the 5 preconfigured rou
 * `936e9d45-15de-4a95-bb36-ae163c33ae53`
 * `9ba00d23-cd6f-4aca-8688-00abc85a7980`
 
-On other environments these values will be established as part of your [NHS Notify service onboarding](#overview--onboarding).
+On other environments these values will be established as part of your [NHS Notify onboarding](#overview--onboarding).
 
 Here is an example curl request which creates a message batch using one of these routing plan identifiers:
 

--- a/specification/responses/4xx/message_batches/404_NoSuchRoutingPlanForBatch.yaml
+++ b/specification/responses/4xx/message_batches/404_NoSuchRoutingPlanForBatch.yaml
@@ -15,7 +15,7 @@ description: |+
 
   If you use a routing plan id that is not in this list then a `404 Not Found` error response will be triggered.
 
-  On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+  On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
 
   Here is an example curl request to trigger a `404`:
 

--- a/specification/responses/4xx/message_batches/404_NoSuchRoutingPlanForBatch.yaml
+++ b/specification/responses/4xx/message_batches/404_NoSuchRoutingPlanForBatch.yaml
@@ -15,7 +15,7 @@ description: |+
 
   If you use a routing plan id that is not in this list then a `404 Not Found` error response will be triggered.
 
-  On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
+  On other environments these values will be established as part of your [NHS Notify onboarding](#overview--onboarding).
 
   Here is an example curl request to trigger a `404`:
 

--- a/specification/responses/4xx/messages/404_NoSuchRoutingPlanForMessage.yaml
+++ b/specification/responses/4xx/messages/404_NoSuchRoutingPlanForMessage.yaml
@@ -15,7 +15,7 @@ description: |+
 
   If you use a routing plan id that is not in this list then a `404 Not Found` error response will be triggered.
 
-  On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+  On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
 
   Here is an example curl request to trigger a `404`:
 

--- a/specification/responses/4xx/messages/404_NoSuchRoutingPlanForMessage.yaml
+++ b/specification/responses/4xx/messages/404_NoSuchRoutingPlanForMessage.yaml
@@ -15,7 +15,7 @@ description: |+
 
   If you use a routing plan id that is not in this list then a `404 Not Found` error response will be triggered.
 
-  On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
+  On other environments these values will be established as part of your [NHS Notify onboarding](#overview--onboarding).
 
   Here is an example curl request to trigger a `404`:
 


### PR DESCRIPTION
## Summary

Updated content in OAS spec to rename Communications Manager to NHS Notify. Haven't changed the spec file name or touched any other naming changes - just user-visible content.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] Branch deployed to a dynamic env - link to deployment pipeline
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
