### PR TITLE
rebranding throughout documentation and specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Communications Manager API
+# NHS Notify API
 
 ![Build](https://github.com/NHSDigital/communications-manager-api/workflows/Build/badge.svg?branch=release)
 
-This is the RESTful API for the [*Communications Manager Service*](https://digital.nhs.uk/developer/api-catalogue/communications-manager).
+This is the RESTful API for the [*NHS Notify Service*](https://digital.nhs.uk/developer/api-catalogue/nhs-notify).
 
 It includes:
 
@@ -16,9 +16,9 @@ It includes:
 * `postman/` - Postman collections.
 * `docs/` - [Documentation for the project](docs/index.md)
 
-Consumers of the API will find developer documentation on the [Communications Manager API entry](https://digital.nhs.uk/developer/api-catalogue/communications-manager).
+Consumers of the API will find developer documentation on the [NHS Notify API entry](https://digital.nhs.uk/developer/api-catalogue/nhs-notify).
 
-This repo does not include the Communications Manager back-end that is not currently open source.
+This repo does not include the NHS Notify back-end that is not currently open source.
 
 ## Contributing
 
@@ -299,7 +299,7 @@ Contains templates defining Azure Devops pipelines. By default the following pip
 
 #### `/proxies`:
 
-This folder contains files relating to the Communications Manager Apigee API proxy.
+This folder contains files relating to the NHS Notify Apigee API proxy.
 
 There are 2 proxy folders `/live` and `/sandbox`. The `/live` folder contains the configuration that is specific to all none sandbox proxy instances - `/sandbox` contains the sandbox proxy definition.
 
@@ -336,7 +336,7 @@ Contains useful scripts that are used throughout the project, these are:
 
 #### `/specification`:
 
-This folder contains the Open API specification for the Communications Manager API. The specification is broken down into multiple files to aid readability and reuse.
+This folder contains the Open API specification for the NHS Notify API. The specification is broken down into multiple files to aid readability and reuse.
 
 #### `/tests`:
 

--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -3,7 +3,7 @@
 The proxy is constructed of two main parts:
 
 * proxy definition
-* communications manager target definition
+* nhs notify target definition
 
 ## Proxy definition
 
@@ -38,7 +38,7 @@ flowchart
 
 ## Target definition
 
-The target definition contains configuration thats specific for calling the backend communications manager API service.
+The target definition contains configuration thats specific for calling the backend nhs notify API service.
 
 This configuration is called via the proxy definition as part of the request routing configuration.
 
@@ -271,7 +271,7 @@ flowchart LR
 
 ### Target PreFlow Request
 
-This defines the actions carried out on all incoming requests to the communications manager target.
+This defines the actions carried out on all incoming requests to the nhs notify target.
 
 Source: [proxies/shared/partials/Partial.Target.PreFlowRequest.xml](https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/partials/Partial.Target.PreFlowRequest.xml)
 
@@ -350,7 +350,7 @@ flowchart
 
 ### Target PreFlow Response
 
-This defines the actions carried out on all outgoing responses from the communications manager target.
+This defines the actions carried out on all outgoing responses from the nhs notify target.
 
 Source: [proxies/shared/partials/Partial.Target.PreFlowResponse.xml](https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/partials/Partial.Target.PreFlowResponse.xml)
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Public facing API for the Communications Manager service",
   "scripts": {
-    "lint": "redocly lint specification/communications-manager.yaml",
-    "publish": "mkdir -p build && redocly bundle specification/communications-manager.yaml --dereferenced --remove-unused-components --ext json | poetry run python scripts/set_version.py > build/communications-manager.json",
+    "lint": "redocly lint specification/nhs-notify.yaml",
+    "publish": "mkdir -p build && redocly bundle specification/nhs-notify.yaml --dereferenced --remove-unused-components --ext json | poetry run python scripts/set_version.py > build/communications-manager.json",
     "serve": "redocly preview-docs -p 5000 build/communications-manager.json",
     "check-licenses": "node_modules/.bin/license-checker --failOn GPL --failOn LGPL --failOn AGPL",
     "sandbox-postman-collection": "newman run postman/CommunicationsManager.Sandbox.postman_collection.json",
@@ -14,7 +14,7 @@
   },
   "author": "NHS Digital",
   "license": "MIT",
-  "homepage": "https://digital.nhs.uk/developer/api-catalogue/communications-manager",
+  "homepage": "https://digital.nhs.uk/developer/api-catalogue/nhs-notify",
   "bugs": {
     "url": "https://github.com/NHSDigital/communications-manager-api/issues"
   },

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -2,18 +2,18 @@
 
 Use this API to send messages to citizens via email, SMS, the NHS App or letter.
 
-Communications Manager provides:
+NHS Notify provides:
 
 * message templating
 * message routing - via SMS, email, letter and NHS App
 * enrichment of recipient details
 * support for accessible formats and multiple languages
 
-For more information about this services capabilities, see [Communications Manager Service](https://digital.nhs.uk/services/communications-manager).
+For more information about this services capabilities, see [NHS Notify Service](https://digital.nhs.uk/services/nhs-notify).
 
 ## Who can use this API
 
-The Communications Manager service is intended for services involved in direct care. This API can only be used where you have a legal basis to issue communications to citizens.
+The NHS Notify service is intended for services involved in direct care. This API can only be used where you have a legal basis to issue communications to citizens.
 
 ## API status and roadmap
 
@@ -126,7 +126,7 @@ Rather, use the [production test patient for PDS](https://digital.nhs.uk/develop
 
 ## Onboarding
 
-You need to get your software approved by us before it can go live with this API. You will also need to undertake the Communications Manager onboarding process which is still being defined. Further details will follow.
+You need to get your software approved by us before it can go live with this API. You will also need to undertake the NHS Notify onboarding process which is still being defined. Further details will follow.
 
 To understand how our online digital onboarding process works, see [digital onboarding](https://digital.nhs.uk/developer/guides-and-documentation/digital-onboarding).
 

--- a/specification/documentation/CreateMessage.md
+++ b/specification/documentation/CreateMessage.md
@@ -28,7 +28,7 @@ When sending this request on sandbox you must use one of the 5 preconfigured rou
 * `936e9d45-15de-4a95-bb36-ae163c33ae53`
 * `9ba00d23-cd6f-4aca-8688-00abc85a7980`
 
-On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
 
 Here is an example curl request which creates a message using one of these routing plan identifiers:
 

--- a/specification/documentation/CreateMessageBatch.md
+++ b/specification/documentation/CreateMessageBatch.md
@@ -33,7 +33,7 @@ When sending this request on sandbox you must use one of the 5 preconfigured rou
 * `936e9d45-15de-4a95-bb36-ae163c33ae53`
 * `9ba00d23-cd6f-4aca-8688-00abc85a7980`
 
-On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
 
 Here is an example curl request which creates a message batch using one of these routing plan identifiers:
 

--- a/specification/nhs-notify.yaml
+++ b/specification/nhs-notify.yaml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 info:
   version: '3.0'
-  title: Communications Manager API
+  title: NHS Notify API
   description:
     $ref: documentation/APIDescription.md
   contact:
-    name: Communications Manager Service API Support
+    name: NHS Notify Service API Support
     url: 'https://digital.nhs.uk/developer/help-and-support'
     email: api.management@nhs.net
 servers:

--- a/specification/responses/4xx/message_batches/404_NoSuchRoutingPlanForBatch.yaml
+++ b/specification/responses/4xx/message_batches/404_NoSuchRoutingPlanForBatch.yaml
@@ -15,7 +15,7 @@ description: |+
 
   If you use a routing plan id that is not in this list then a `404 Not Found` error response will be triggered.
 
-  On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+  On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
 
   Here is an example curl request to trigger a `404`:
 

--- a/specification/responses/4xx/messages/404_NoSuchRoutingPlanForMessage.yaml
+++ b/specification/responses/4xx/messages/404_NoSuchRoutingPlanForMessage.yaml
@@ -15,7 +15,7 @@ description: |+
 
   If you use a routing plan id that is not in this list then a `404 Not Found` error response will be triggered.
 
-  On other environments these values will be established as part of your [Communications Manager Service onboarding](#overview--onboarding).
+  On other environments these values will be established as part of your [NHS Notify Service onboarding](#overview--onboarding).
 
   Here is an example curl request to trigger a `404`:
 


### PR DESCRIPTION
## Summary

This is a suggested pull request for updating the documentation to rebrand from Communciations Manager to NHS Notify.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] Branch deployed to a dynamic env - link to deployment pipeline
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
