### PR TITLE
CCM-3210: fix calculate_version.py for calculating patch versions

### DIFF
--- a/scripts/calculate_version.py
+++ b/scripts/calculate_version.py
@@ -116,8 +116,7 @@ def calculate_version(base_major=1, base_minor=0, base_revision=0, base_pre="alp
     # If there are any +patch in commit messages, increment the counter
     # We only care about commits after the last minor increment
     commits = list(itertools.takewhile(lambda c: not is_minor_inc(c), commits))
-    commits = list(without_empty(commits))
-    patch_incs = [c for c in commits if is_minor_inc(c)]
+    patch_incs = [c for c in commits if is_patch_inc(c)]
 
     if patch_incs:
         patch += len(patch_incs)


### PR DESCRIPTION
## Summary

Fix calculate_version.py for patch version

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] ~Branch deployed to a dynamic env - link to deployment pipeline~
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
