### PR TITLE
CCM-3517: amend assert_200_response_message to handle prod url

### DIFF
--- a/tests/development/messages/get_message/test_success.py
+++ b/tests/development/messages/get_message/test_success.py
@@ -21,8 +21,7 @@ def test_200_get_message(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_hea
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(
-        resp, "internal-qa" if "internal-qa" in nhsd_apim_proxy_url else "internal-dev")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
 
 
 @pytest.mark.devtest
@@ -40,8 +39,7 @@ def test_200_get_message_pending_enrichment(nhsd_apim_proxy_url, nhsd_apim_auth_
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(
-        resp, "internal-qa" if "internal-qa" in nhsd_apim_proxy_url else "internal-dev")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
     Assertions.assert_get_message_status(resp, "pending_enrichment")
 
 
@@ -60,8 +58,7 @@ def test_200_get_message_sending(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ac
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(
-        resp, "internal-qa" if "internal-qa" in nhsd_apim_proxy_url else "internal-dev")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
     Assertions.assert_get_message_status(resp, "sending")
 
 
@@ -80,8 +77,7 @@ def test_200_get_message_successful(nhsd_apim_proxy_url, nhsd_apim_auth_headers,
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(
-        resp, "internal-qa" if "internal-qa" in nhsd_apim_proxy_url else "internal-dev")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
     Assertions.assert_get_message_status(resp, "delivered")
 
 
@@ -100,8 +96,7 @@ def test_200_get_message_failed(nhsd_apim_proxy_url, nhsd_apim_auth_headers, acc
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(
-        resp, "internal-qa" if "internal-qa" in nhsd_apim_proxy_url else "internal-dev")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
     Assertions.assert_get_message_status(resp, "failed", "Failed reason: patient has exit code")
 
 
@@ -120,7 +115,6 @@ def test_200_get_message_cascade(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ac
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(
-        resp, "internal-qa" if "internal-qa" in nhsd_apim_proxy_url else "internal-dev")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
     Assertions.assert_get_message_status(resp, "sending")
     Assertions.assert_get_message_response_channels(resp, CHANNEL_TYPE, CHANNEL_STATUS)

--- a/tests/integration/messages/get_message/test_success.py
+++ b/tests/integration/messages/get_message/test_success.py
@@ -16,5 +16,5 @@ def test_200_get_message(message_ids):
         f"{INT_URL}{MESSAGES_ENDPOINT}/{message_ids}",
         headers={"Authorization": Authentication.generate_authentication("int")}
         )
-    Assertions.assert_200_response_message(resp, "int")
+    Assertions.assert_200_response_message(resp, INT_URL)
     Assertions.assert_get_message_response_channels(resp, "email", "delivered")

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -27,7 +27,7 @@ class Assertions():
         assert resp.headers.get("Cache-Control") == "no-cache, no-store, must-revalidate"
 
     @staticmethod
-    def assert_200_response_message(resp, environment):
+    def assert_200_response_message(resp, base_url):
         Error_Handler.handle_retry(resp)
 
         assert resp.status_code == 200
@@ -73,17 +73,7 @@ class Assertions():
             assert response.get("attributes").get("channels")[0].get("timestamps") != ""
             assert response.get("attributes").get("channels")[0].get("routingPlan") is not None
             assert response.get("attributes").get("channels")[0].get("routingPlan") != ""
-
-        hostname = f"{environment}.api.service.nhs.uk"
-        prefixes = ["internal-dev", "internal-qa"]
-
-        if environment == 'sandbox':
-            for p in prefixes:
-                if p in response.get("links").get("self"):
-                    hostname = f"{p}-{hostname}"
-                    break
-
-        assert response.get("links").get("self").startswith(f"https://{hostname}/comms")
+        assert response.get("links").get("self").startswith(base_url)
         assert response.get("links").get("self").endswith(f"/v1/messages/{response.get('id')}")
 
     @staticmethod

--- a/tests/production/messages/get_message/test_success.py
+++ b/tests/production/messages/get_message/test_success.py
@@ -17,5 +17,5 @@ def test_200_get_message(message_ids):
         f"{PROD_URL}{MESSAGES_ENDPOINT}/{message_ids}",
         headers={"Authorization": Authentication.generate_authentication("prod")}
         )
-    Assertions.assert_200_response_message(resp, "prod")
+    Assertions.assert_200_response_message(resp, PROD_URL)
     Assertions.assert_get_message_response_channels(resp, "email", "delivered")

--- a/tests/sandbox/messages/get_message/test_success.py
+++ b/tests/sandbox/messages/get_message/test_success.py
@@ -26,7 +26,7 @@ def test_200_get_message_valid_accept_headers(nhsd_apim_proxy_url, accept_header
             "Content-Type": "application/json"
         },
     )
-    Assertions.assert_200_response_message(resp, "sandbox")
+    Assertions.assert_200_response_message(resp, nhsd_apim_proxy_url)
 
 
 @pytest.mark.parametrize('message_ids', get_200_message_ids())


### PR DESCRIPTION
## Summary

The assert_200_response_message function checks various properties of the response returned by APIM. One such property is the url of links. In Prod it was incorrectly checking that it begins with prod.api.service.nhs.uk, when it's actually api.service.nhs.uk.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/0fd16cc5-b618-4ef4-b613-9ff6a8b78096)
The test passing in 6 of the 7 environments has been confirmed locally(see below). Currently unable to test `prod-sandbox-test` locally, but will try and resolve that before merging.

## Evidence of Completion
### internal-dev-test
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/df09531e-11a5-4040-be7f-cea27f22c78f)
### internal-sandbox-test dev
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/f83c5cfa-640e-4c78-8f7c-528ff4c76f04)
### internal-sandbox-test qa
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/75cb8261-f1b4-4eeb-b602-7e36ea7d733b)
### internal-qa-test
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/a9211794-4268-46e5-9a69-9fb6e92a861c)
### integration-test
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/fa8cb763-ae04-4f29-94fc-4eff655d75f5)
### production-test
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/c9c6726d-d02a-4b80-9ef3-885ef17664a9)

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] Branch deployed to a dynamic env - link to deployment pipeline
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
