### PR TITLE
CCM-4566 fix zap vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ tmp/
 tests/locust/*.html
 postman/Integration.test.postman_environment.json
 sandbox/test-results.xml
+.vscode/*

--- a/azure/nightly-zap-scan-pipeline.yml
+++ b/azure/nightly-zap-scan-pipeline.yml
@@ -35,18 +35,14 @@ steps:
     parameters:
       secret_file_ids:
       - ptl/api-deployment/communications-manager/INTEGRATION_PRIVATE_KEY
-      - ptl/azure-devops/communications-manager/PRODUCTION_PRIVATE_KEY
       secret_ids:
       - ptl/api-deployment/communications-manager/INTEGRATION_API_KEY
-      - ptl/azure-devops/communications-manager/PRODUCTION_API_KEY
   - template: ./templates/teams-alert-setup.yml
     parameters:
       webhook_uri: 'ALERTS_DEV_API_WEBHOOK_URI'
   - bash: |
       export INTEGRATION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(INTEGRATION_PRIVATE_KEY)"
       export INTEGRATION_API_KEY="$(INTEGRATION_API_KEY)"
-      export PRODUCTION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(PRODUCTION_PRIVATE_KEY)"
-      export PRODUCTION_API_KEY="$(PRODUCTION_API_KEY)"
       make install-python && make zap-security-scan    
     displayName: Run OWASP zap scan
   - task: PublishTestResults@2

--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -277,8 +277,7 @@ Source: [proxies/shared/partials/Partial.Target.PreFlowRequest.xml](https://gith
 
 ```mermaid
 flowchart
-    S[Start] --> SRD["<a href='https://github.com/NHSDigital/communications-manager-api/blob/release/docs/proxies.md#set-response-defaults'>Set response defaults</a>"]
-    SRD --> SBCI["Set the backend request correlation id
+    S[Start] --> SBCI["Set the backend request correlation id
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/JavaScript.SetBackendCorrelationId.xml'>JavaScript.SetBackendCorrelationId</a></em>"]
     SBCI --> ADRP["Sets a default request path
@@ -346,20 +345,6 @@ flowchart
 
     <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/RaiseFault.405NotAllowed.xml'>RaiseFault.405NotAllowed</a></em>"]
     405 --> E
-```
-
-### Target PreFlow Response
-
-This defines the actions carried out on all outgoing responses from the communications manager target.
-
-Source: [proxies/shared/partials/Partial.Target.PreFlowResponse.xml](https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/partials/Partial.Target.PreFlowResponse.xml)
-
-```mermaid
-flowchart LR
-    S[Start] --> AD["Add CORS headers
-
-    <em><a href='https://github.com/NHSDigital/communications-manager-api/blob/release/proxies/shared/policies/AssignMessage.AddCors.xml'>AssignMessage.AddCors</a></em>"]
-    AD --> E[End]
 ```
 
 ### Create Message Batch

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -3,9 +3,6 @@
         <Request>
             [% include './partials/Partial.Target.PreFlowRequest.xml' %]
         </Request>
-        <Response>
-            [% include './partials/Partial.Target.PreFlowResponse.xml' %]
-        </Response>
     </PreFlow>
     <Flows>
         [% include './partials/Partial.Flows.CreateMessageBatchEndpoint.xml' %]

--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -3,9 +3,6 @@
         <Request>
             [% include './partials/Partial.Target.PreFlowRequest.xml' %]
         </Request>
-        <Response>
-            [% include './partials/Partial.Target.PreFlowResponse.xml' %]
-        </Response>
     </PreFlow>
     <Flows>
         [% include './partials/Partial.Flows.CreateMessageBatchEndpoint.xml' %]

--- a/proxies/shared/partials/Partial.Target.PreFlowRequest.xml
+++ b/proxies/shared/partials/Partial.Target.PreFlowRequest.xml
@@ -1,4 +1,3 @@
-[% include './partials/Partial.Component.SetResponseDefaults.xml' %]
 <Step>
     <Name>JavaScript.SetBackendCorrelationId</Name>
 </Step>

--- a/proxies/shared/partials/Partial.Target.PreFlowResponse.xml
+++ b/proxies/shared/partials/Partial.Target.PreFlowResponse.xml
@@ -1,3 +1,0 @@
-<Step>
-    <Name>AssignMessage.AddCors</Name>
-</Step>

--- a/scripts/publish_zap_compatible.py
+++ b/scripts/publish_zap_compatible.py
@@ -34,7 +34,8 @@ with open('build/communications-manager-zap.json', 'w') as f:
             specification,
             (
                 ("format", "date"),
-                ("personalisation", None)
+                ("personalisation", None),
+                ("/callbacks", None)
             )
         ),
         f

--- a/scripts/run_zap.sh
+++ b/scripts/run_zap.sh
@@ -17,7 +17,6 @@ mv .python-version.ignore .python-version
 
 # open the contents in INTEGRATION_PRIVATE_KEY and put it into INTEGRATION_PRIVATE_KEY_CONTENTS
 export INTEGRATION_PRIVATE_KEY_CONTENTS=$(cat $INTEGRATION_PRIVATE_KEY)
-export PRODUCTION_PRIVATE_KEY_CONTENTS=$(cat $PRODUCTION_PRIVATE_KEY)
 
 docker build -t zap -f ./zap/Dockerfile .
 
@@ -25,8 +24,6 @@ docker build -t zap -f ./zap/Dockerfile .
 docker container run \
     --env INTEGRATION_PRIVATE_KEY_CONTENTS="$INTEGRATION_PRIVATE_KEY_CONTENTS" \
     --env INTEGRATION_API_KEY="$INTEGRATION_API_KEY" \
-    --env PRODUCTION_PRIVATE_KEY_CONTENTS="$PRODUCTION_PRIVATE_KEY_CONTENTS" \
-    --env PRODUCTION_API_KEY="$PRODUCTION_API_KEY" \
     -v $(pwd):/zap/wrk/:rw \
     -v $TEMP_DIR:/zap/tmp/:rw \
     -v $(pwd)/zap/comms-manager-json/:/home/zap/.ZAP/reports/comms-manager-json/:rw \

--- a/zap/zap.yaml
+++ b/zap/zap.yaml
@@ -10,41 +10,20 @@ env:
       urls:
         - https://int.api.service.nhs.uk/comms # the actual url used for the scan is defined in the openapi job below
       authentication:
-        method: 'script'
+        method: script
         parameters:
           url: https://int.api.service.nhs.uk/oauth2/token
-          script: 'scripts/authentication/get_bearer_token.js'
-          scriptEngine: 'Graal.js'
+          script: scripts/authentication/get_bearer_token.js
+          scriptEngine: Graal.js
         verification:
-          method: 'response'
-          loggedOutRegex: '401 Unauthorized'
+          method: response
+          loggedOutRegex: 401 Unauthorized
       users:
         - name: Integration
           credentials:
             kid: local
-            api_key: "${INTEGRATION_API_KEY}"
-            private_key: "${INTEGRATION_PRIVATE_KEY_CONTENTS}"
-    - name: ProdUnauthenticated
-      urls:
-        - https://api.service.nhs.uk/comms # the actual url used for the scan is defined in the openapi job below
-    - name: ProdAuthenticated
-      urls:
-        - https://api.service.nhs.uk/comms # the actual url used for the scan is defined in the openapi job below
-      authentication:
-        method: 'script'
-        parameters:
-          url: https://api.service.nhs.uk/oauth2/token
-          script: 'scripts/authentication/get_bearer_token.js'
-          scriptEngine: 'Graal.js'
-        verification:
-          method: 'response'
-          loggedOutRegex: '401 Unauthorized'
-      users:
-        - name: Prod
-          credentials:
-            kid: prod-1
-            api_key: "${PRODUCTION_API_KEY}"
-            private_key: "${PRODUCTION_PRIVATE_KEY_CONTENTS}"
+            api_key: ${INTEGRATION_API_KEY}
+            private_key: ${INTEGRATION_PRIVATE_KEY_CONTENTS}
   parameters:
     failOnError: true
     failOnWarning: true
@@ -54,46 +33,83 @@ jobs:
   # load our authentication and httpsender script
   - type: script
     parameters:
-      action: 'add'
-      type: 'httpsender'
-      engine: 'Graal.js'
-      name: 'add_bearer_token'
-      file: 'scripts/httpsender/add_bearer_token.js'
+      action: add
+      type: httpsender
+      engine: Graal.js
+      name: add_bearer_token
+      file: scripts/httpsender/add_bearer_token.js
   - type: script
     parameters:
-      action: 'add'
-      type: 'authentication'
-      engine: 'Graal.js'
-      name: 'get_bearer_token'
-      file: 'scripts/authentication/get_bearer_token.js'
+      action: add
+      type: authentication
+      engine: Graal.js
+      name: get_bearer_token
+      file: scripts/authentication/get_bearer_token.js
+
+  # configure the passive scan
+  - type: passiveScan-config
+    parameters:
+      maxAlertsPerRule: 10
+      scanOnlyInScope: true
+    rules:
+      - id: 10049
+        name: Non-Storable Content
+        threshold: Off
+        # We do not want responses cached.
+        # See https://github.com/NHSDigital/communications-manager-api/pull/548 for more information.
+
+      - id: 90005
+        name: Sec-Fetch-Site Header is Missing
+        threshold: Off
+        # Sec-Fetch-* headers are only for requests.
+        # See https://github.com/NHSDigital/communications-manager-api/pull/548 for more information.
+
+      - id: 10094
+        name: Base64 Disclosure
+        threshold: Off
+        # The KSUIDs are sometimes detected as base64 strings.
+        # See https://github.com/NHSDigital/communications-manager-api/pull/548 for more information.
+
+      - id: 110009
+        name: Full Path Disclosure
+        threshold: Off
+        # Error responses include a link to the NHS developer catalogue.
+        # ZAP is picking up 'developer' in the link.
+        # See https://github.com/NHSDigital/communications-manager-api/pull/548 for more information.
+
+      - id: 90004
+        name: Insufficient Site Isolation Against Spectre Vulnerability
+        threshold: Off
+        # CORS headers (including Cross-Origin-Resource-Policy) are only added to the response when the request has an origin specified.
+        # See https://github.com/NHSDigital/communications-manager-api/pull/548 for more information.
+
+      - id: 10062
+        name: PII Disclosure
+        threshold: Off
+        # Error responses include the apigee message id in the body.
+        # Sometimes it can be detected as a Maestro credit card number.
+        # This rule only checks for credit card details, no other PII.
+        # See https://github.com/NHSDigital/communications-manager-api/pull/548 for more information.
 
   # load the zap specific openapi specification
   - type: openapi
     parameters:
-      apiFile: '/zap/wrk/build/communications-manager-zap.json'
+      apiFile: /zap/wrk/build/communications-manager-zap.json
       targetUrl: https://sandbox.api.service.nhs.uk/comms
       context: Sandbox
   - type: openapi
     parameters:
-      apiFile: '/zap/wrk/build/communications-manager-zap.json'
+      apiFile: /zap/wrk/build/communications-manager-zap.json
       targetUrl: https://int.api.service.nhs.uk/comms
       context: IntegrationUnauthenticated
   - type: openapi
     parameters:
-      apiFile: '/zap/wrk/build/communications-manager-zap.json'
+      apiFile: /zap/wrk/build/communications-manager-zap.json
       targetUrl: https://int.api.service.nhs.uk/comms
       context: IntegrationAuthenticated
-  - type: openapi
-    parameters:
-      apiFile: '/zap/wrk/build/communications-manager-zap.json'
-      targetUrl: https://api.service.nhs.uk/comms
-      context: ProdUnauthenticated
-  - type: openapi
-    parameters:
-      apiFile: '/zap/wrk/build/communications-manager-zap.json'
-      targetUrl: https://api.service.nhs.uk/comms
-      context: ProdAuthenticated
 
+  # let the passive scan do it's stuff
+  - type: passiveScan-wait
 
   # run an active scan on sandbox
   - type: activeScan
@@ -123,31 +139,12 @@ jobs:
       delayInMs: 500
       threadPerHost: 1
 
-   # run an active scan on prod, using unauthenticated calls
-  - type: activeScan
-    parameters:
-      policy: API
-      context: ProdUnauthenticated
-      scanHeadersAllRequests: true
-      delayInMs: 500
-      threadPerHost: 1
-
-  # run an active scan on prod, using authenticated calls
-  - type: activeScan
-    parameters:
-      policy: API
-      context: ProdAuthenticated
-      user: Prod
-      scanHeadersAllRequests: true
-      delayInMs: 500
-      threadPerHost: 1
-
   # generate our custom JSON report
   - type: report
     parameters:
-      template: 'comms-manager-json'
-      reportDir: '/zap/tmp'
-      reportFile: 'zap-report.json'
+      template: comms-manager-json
+      reportDir: /zap/tmp
+      reportFile: zap-report.json
     risks:
       - high
       - medium


### PR DESCRIPTION
## Summary

Actioning the ZAP issues so the workflow runs green.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval

## Test Evidence

Successful security scan: https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId=211413&view=results

## Detail of Changes

### Rule Exclusions

#### 10049 - Non-Storable Content
We do not want the responses to be cached, and set the headers to indicate this.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/41452c49-fdee-4e03-bf58-94e70e4086b2)

#### 90005 - Sec-Fetch-Site Header is Missing
Sec-Fetch-* headers are only for requests. This rule is not relevant for APIs on their own.

#### 10094 - Base64 Disclosure
The KSUIDs are sometimes being detected as base64 strings.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/d125709a-fc8f-4c39-a0d9-99780b5492a3)

#### 110009 - Full Path Disclosure
In our error responses we include a link to the NHS developer catalogue.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/fbf58823-56ce-4324-8bf8-b81c00c69f88)
The ZAP code is picking up `developer`.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/1959e9cd-7ab8-4ff1-ad8a-d7f7bf8be0d1)

#### 90004 - Insufficient Site Isolation Against Spectre Vulnerability
When there is no Origin header in the request, we do not include the CORS headers in the response. This includes the Cross-Origin-Resource-Policy, which is what ZAP is flagging.

#### 10062 - PII Disclosure
In our error responses we include the apigee message id in the body.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/3f7e68c1-4011-4359-9142-df2c158bff54)
Sometimes it can be detected as a Maestro credit card number. Note, this rule only checks for credit card details, no other PII.
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/db8b3e5c-60c8-4520-bcac-04a8276f754a)

### Removal of Production Scans
These ZAP scans are not intended to be ran against a production environment. Unintended actions could be performed. The Integration environment is sufficiently production-like to test against.

### CORS Headers
The CORS headers were not implemented correctly. It has been changed so an OPTIONS request returns the following CORS headers.
With an origin:
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/4cf9f0f6-ef61-444c-a206-e735f35d24c8)
Without:
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/47b7bea9-2cf3-48d9-a3c8-124468db545b)
All other requests return the following headers.
With an origin:
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/86e6f520-0428-4685-8e14-ce7666636234)
Without:
![image](https://github.com/NHSDigital/communications-manager-api/assets/13391709/abc3eb20-d6fb-427b-beab-9ff2c88ec9fa)

### Remove Scanning of /callbacks 
There is a callback endpoint in the api specifications, but it's not one we host. It is there as a guide for consumers on setting up such an endpoint on their system to receive status updates from NHS Notify. Including it has no benefit and increases the scan duration.