### PR TITLE
CCM-2615: added NHS Number link to docs in spec

### DIFF
--- a/specification/schemas/enums/ErrorInvalidValue.yaml
+++ b/specification/schemas/enums/ErrorInvalidValue.yaml
@@ -8,5 +8,5 @@ enum:
   - CM_TOO_FEW_ITEMS
   - CM_ODS_CODE_REQUIRED
   - CM_CANNOT_SET_ODS_CODE
-example: CM_MISSING_VALUE
+example: CM_INVALID_NHS_NUMBER
 title: Enum_Error_InvalidValue

--- a/specification/schemas/responses/errors/message_batches/UnableToProcessBatch.yaml
+++ b/specification/schemas/responses/errors/message_batches/UnableToProcessBatch.yaml
@@ -15,7 +15,7 @@ properties:
         code:
           $ref: ../../../enums/ErrorInvalidValue.yaml
         links:
-          $ref: ../../../types/LinksError.yaml
+          $ref: ../../../types/LinksErrorNHSNumber.yaml
         status:
           type: string
           enum:

--- a/specification/schemas/responses/errors/messages/UnableToProcessMessage.yaml
+++ b/specification/schemas/responses/errors/messages/UnableToProcessMessage.yaml
@@ -15,7 +15,7 @@ properties:
         code:
           $ref: ../../../enums/ErrorInvalidValue.yaml
         links:
-          $ref: ../../../types/LinksError.yaml
+          $ref: ../../../types/LinksErrorNHSNumber.yaml
         status:
           type: string
           enum:

--- a/specification/schemas/types/LinksErrorNHSNumber.yaml
+++ b/specification/schemas/types/LinksErrorNHSNumber.yaml
@@ -6,4 +6,9 @@ properties:
     format: uri
     example: 'https://digital.nhs.uk/developer/api-catalogue/communications-manager'
     description: 'https://digital.nhs.uk/developer/api-catalogue/communications-manager'
+  nhsNumbers:
+    type: string
+    format: uri
+    example: 'https://www.datadictionary.nhs.uk/attributes/nhs_number.html'
+    description: https://www.datadictionary.nhs.uk/attributes/nhs_number.html This link is only provided in the instance of a "CM_INVALID_NHS_NUMBER" error.
 minProperties: 1


### PR DESCRIPTION
## Summary
Added NHSnumber link info to status 400 info in:
https://digital.nhs.uk/developer/api-catalogue/nhs-notify#post-/v1/message-batches
https://digital.nhs.uk/developer/api-catalogue/nhs-notify#post-/v1/messages

## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] Branch deployed to a dynamic env - link to deployment pipeline
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
