### PR TITLE
CCM-5423: removed dyn env deploy check item from MR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,6 @@
 ## Checklist
 * [ ] Brief description of work completed, and any technical decisions made as part of the PR
 * [ ] PR link added as a comment to the relevant JIRA ticket
-* [ ] Branch deployed to a dynamic env - link to deployment pipeline
 * [ ] PR link shared on Slack and/or Teams
 * [ ] 2 reviews received
 * [ ] Tester approval


### PR DESCRIPTION
## Summary
CCM-5423: removed dyn env deploy check item from MR template


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] Branch deployed to a dynamic env - link to deployment pipeline
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
