### PR TITLE
CCM-4969: update test assertions for auto generated correlation ids

### DIFF
--- a/tests/development/headers/test_x_correlation_id.py
+++ b/tests/development/headers/test_x_correlation_id.py
@@ -32,4 +32,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"), correlation_id)

--- a/tests/development/headers/test_x_correlation_id.py
+++ b/tests/development/headers/test_x_correlation_id.py
@@ -1,6 +1,6 @@
 import requests
 import pytest
-from lib import Error_Handler
+from lib import Error_Handler, Assertions
 from lib.constants.constants import VALID_ENDPOINTS
 
 
@@ -32,4 +32,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    assert resp.headers.get("x-correlation-id") == correlation_id
+    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))

--- a/tests/development/headers/test_x_correlation_id.py
+++ b/tests/development/headers/test_x_correlation_id.py
@@ -32,4 +32,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))

--- a/tests/integration/headers/test_x_correlation_id.py
+++ b/tests/integration/headers/test_x_correlation_id.py
@@ -21,4 +21,4 @@ def test_request_with_x_correlation_id(correlation_id, method, endpoints):
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))

--- a/tests/integration/headers/test_x_correlation_id.py
+++ b/tests/integration/headers/test_x_correlation_id.py
@@ -21,4 +21,4 @@ def test_request_with_x_correlation_id(correlation_id, method, endpoints):
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"), correlation_id)

--- a/tests/integration/headers/test_x_correlation_id.py
+++ b/tests/integration/headers/test_x_correlation_id.py
@@ -1,6 +1,6 @@
 import requests
 import pytest
-from lib import Authentication, Error_Handler
+from lib import Authentication, Error_Handler, Assertions
 from lib.constants.constants import INT_URL, METHODS, VALID_ENDPOINTS
 
 CORRELATION_IDS = [None, "a17669c8-219a-11ee-ba86-322b0407c489"]
@@ -21,4 +21,4 @@ def test_request_with_x_correlation_id(correlation_id, method, endpoints):
 
     Error_Handler.handle_retry(resp)
 
-    assert resp.headers.get("x-correlation-id") == correlation_id
+    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -271,11 +271,12 @@ class Assertions():
             else:
                 assert error in response_errors
 
-        resCorrelationID = resp.headers.get("X-Correlation-Id")
+        res_correlation_id = resp.headers.get("X-Correlation-Id")
         # apigee generates this value if not present with rrt prefix
-        isValidCorrelationID = (resCorrelationID == correlation_id
-                                or (correlation_id is None and resCorrelationID.startswith('rrt')))
-        assert isValidCorrelationID
+        if correlation_id:
+            assert res_correlation_id == correlation_id
+        else:
+            assert res_correlation_id.startswith('rrt')
 
         # ensure we have our x-content-type-options set correctly
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -271,7 +271,7 @@ class Assertions():
             else:
                 assert error in response_errors
 
-        Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
+        Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"), correlation_id)
 
         # ensure we have our x-content-type-options set correctly
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"
@@ -280,12 +280,12 @@ class Assertions():
         assert resp.headers.get("Cache-Control") == "no-cache, no-store, must-revalidate"
 
     @staticmethod
-    def assert_correlation_id(correlation_id):
+    def assert_correlation_id(res_correlation_id, correlation_id):
         # apigee generates this value if not present with rrt prefix
         if correlation_id:
-            assert correlation_id == correlation_id
+            assert res_correlation_id == correlation_id
         else:
-            assert correlation_id.startswith('rrt')
+            assert res_correlation_id.startswith('rrt')
 
     @staticmethod
     def assert_cors_response(resp, website):

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -272,8 +272,9 @@ class Assertions():
                 assert error in response_errors
 
         resCorrelationID = resp.headers.get("X-Correlation-Id")
-        #apigee generates this value if not present with rrt prefix
-        isValidCorrelationID = resCorrelationID == correlation_id or (correlation_id is None and resCorrelationID.startswith('rrt'))
+        # apigee generates this value if not present with rrt prefix
+        isValidCorrelationID = (resCorrelationID == correlation_id
+                                or  (correlation_id is None and resCorrelationID.startswith('rrt')))
         assert isValidCorrelationID
 
         # ensure we have our x-content-type-options set correctly

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -274,7 +274,7 @@ class Assertions():
         resCorrelationID = resp.headers.get("X-Correlation-Id")
         # apigee generates this value if not present with rrt prefix
         isValidCorrelationID = (resCorrelationID == correlation_id
-                                or  (correlation_id is None and resCorrelationID.startswith('rrt')))
+                                or (correlation_id is None and resCorrelationID.startswith('rrt')))
         assert isValidCorrelationID
 
         # ensure we have our x-content-type-options set correctly

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -271,7 +271,10 @@ class Assertions():
             else:
                 assert error in response_errors
 
-        assert resp.headers.get("X-Correlation-Id") == correlation_id
+        resCorrelationID = resp.headers.get("X-Correlation-Id")
+        #apigee generates this value if not present with rrt prefix
+        isValidCorrelationID = resCorrelationID == correlation_id or (correlation_id is None and resCorrelationID.startswith('rrt'))
+        assert isValidCorrelationID
 
         # ensure we have our x-content-type-options set correctly
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -271,7 +271,7 @@ class Assertions():
             else:
                 assert error in response_errors
 
-        assert Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
+        Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
 
         # ensure we have our x-content-type-options set correctly
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -271,18 +271,21 @@ class Assertions():
             else:
                 assert error in response_errors
 
-        res_correlation_id = resp.headers.get("X-Correlation-Id")
-        # apigee generates this value if not present with rrt prefix
-        if correlation_id:
-            assert res_correlation_id == correlation_id
-        else:
-            assert res_correlation_id.startswith('rrt')
+        assert Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
 
         # ensure we have our x-content-type-options set correctly
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"
 
         # ensure we have our cache-control set correctly
         assert resp.headers.get("Cache-Control") == "no-cache, no-store, must-revalidate"
+
+    @staticmethod
+    def assert_correlation_id(correlation_id):
+        # apigee generates this value if not present with rrt prefix
+        if correlation_id:
+            assert correlation_id == correlation_id
+        else:
+            assert correlation_id.startswith('rrt')
 
     @staticmethod
     def assert_cors_response(resp, website):

--- a/tests/production/headers/test_x_correlation_id.py
+++ b/tests/production/headers/test_x_correlation_id.py
@@ -24,4 +24,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))

--- a/tests/production/headers/test_x_correlation_id.py
+++ b/tests/production/headers/test_x_correlation_id.py
@@ -24,4 +24,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"), correlation_id)

--- a/tests/production/headers/test_x_correlation_id.py
+++ b/tests/production/headers/test_x_correlation_id.py
@@ -1,6 +1,6 @@
 import requests
 import pytest
-from lib import Authentication, Error_Handler
+from lib import Authentication, Error_Handler, Assertions
 from lib.constants.constants import METHODS, PROD_URL
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
 
@@ -24,4 +24,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    assert resp.headers.get("x-correlation-id") == correlation_id
+    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))

--- a/tests/sandbox/headers/test_x_correlation_id.py
+++ b/tests/sandbox/headers/test_x_correlation_id.py
@@ -23,4 +23,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))

--- a/tests/sandbox/headers/test_x_correlation_id.py
+++ b/tests/sandbox/headers/test_x_correlation_id.py
@@ -23,4 +23,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"))
+    Assertions.assert_correlation_id(resp.headers.get("X-Correlation-Id"), correlation_id)

--- a/tests/sandbox/headers/test_x_correlation_id.py
+++ b/tests/sandbox/headers/test_x_correlation_id.py
@@ -1,7 +1,7 @@
 import requests
 import pytest
 from lib.constants.constants import CORRELATION_IDS, METHODS, VALID_ENDPOINTS
-from lib import Error_Handler
+from lib import Error_Handler, Assertions
 
 
 @pytest.mark.sandboxtest
@@ -23,4 +23,4 @@ def test_request_with_x_correlation_id(
 
     Error_Handler.handle_retry(resp)
 
-    assert resp.headers.get("x-correlation-id") == correlation_id
+    Assertions.assert_correlation_id(resp.headers.get("x-correlation-id"))


### PR DESCRIPTION
as part of CCM-4969, the apigee config was changed to autogenerate correlation ids for all requests and to map them back in the response from api gateway. This broke one of the test assertions which checked correlation id was not present if not provided. 

I have updated this to check for an autogenerated id starting with rrt for apigee generated ids.

## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
