### PR TITLE
CCM 5695 missing querystring params

### DIFF
--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -32,7 +32,7 @@ paths:
         description: The unique identifier for the message
     get:
       $ref: endpoints/get_message.yaml
-  /comms/channels/nhsapp/accounts:
+  /channels/nhsapp/accounts:
     parameters:
       - schema:
         $ref: schemas/types/ODSOrganisationCode.yaml

--- a/specification/endpoints/get_nhsapp_account_details.yaml
+++ b/specification/endpoints/get_nhsapp_account_details.yaml
@@ -5,6 +5,8 @@ operationId: get-nhsapp-account-details
 parameters:
   - $ref: ../snippets/AuthorizationParameter.yaml
   - $ref: ../snippets/CorrelationParameter.yaml
+  - $ref: ../snippets/ODSOrganisationCodeParameter.yaml
+  - $ref: ../snippets/PageNumberParameter.yaml
 responses:
   '200':
     $ref: ../responses/2xx/200_NhsAppAccountDetails.yaml

--- a/specification/snippets/ODSOrganisationCodeParameter.yaml
+++ b/specification/snippets/ODSOrganisationCodeParameter.yaml
@@ -1,0 +1,7 @@
+name: ods-organisation-code
+in: query
+required: true
+description: The Organisation Data Service (ODS) code of the GP practice for which to retrieve a list of NHS App users. Not case sensitive.
+schema:
+  $ref: ../schemas/types/ODSOrganisationCode.yaml
+  type: string

--- a/specification/snippets/PageNumberParameter.yaml
+++ b/specification/snippets/PageNumberParameter.yaml
@@ -1,0 +1,9 @@
+name: page
+in: query
+description: |-
+  The ordinal number of the page of results to be retrieved. If omitted, the
+  first page of results will be returned. Use the links section in the response
+  body to determine whether any further pages of results exist.
+schema:
+  type: number
+  example: 1


### PR DESCRIPTION
## Summary

This adds the documentation for the query string parameters to somewhere bloomreach will render it. We reproduced the problem documented in bloomreach and confirmed that this solution showed the documentation as updated. The documentation text is exactly what was already approved.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
