### PR TITLE
ccm-5115 auth fixtures with pipeline fix

### DIFF
--- a/azure/templates/run-tests.yml
+++ b/azure/templates/run-tests.yml
@@ -21,10 +21,12 @@ steps:
     parameters:
       secret_file_ids:
       - ptl/app-credentials/jwt_testing/non-prod/JWT_TESTING_PRIVATE_KEY
+      - ptl/api-deployment/communications-manager/NON_PROD_PRIVATE_KEY
       - ptl/api-deployment/communications-manager/INTEGRATION_PRIVATE_KEY
       - ptl/azure-devops/communications-manager/PRODUCTION_PRIVATE_KEY
       secret_ids:
       - ptl/app-credentials/communications-manager-testing-app/non-prod/SANDBOX_APP_ID
+      - ptl/api-deployment/communications-manager/NON_PROD_API_KEY
       - ptl/api-deployment/communications-manager/INTEGRATION_API_KEY
       - ptl/azure-devops/communications-manager/PRODUCTION_API_KEY
       - ptl/api-deployment/communications-manager/GUKN_API_KEY
@@ -123,6 +125,8 @@ steps:
           apigee_password: $(APIGEE_PASSWORD)
       - bash: |
           export PROXY_NAME="communications-manager-${{parameters.environment}}"
+          export NON_PROD_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(NON_PROD_PRIVATE_KEY)"
+          export NON_PROD_API_KEY="$(NON_PROD_API_KEY)"
           export APIGEE_ACCESS_TOKEN="$(secret.AccessToken)"
           export APIGEE_APP_ID="$(SANDBOX_APP_ID)"
           export STATUS_ENDPOINT_API_KEY="$(STATUS_ENDPOINT_API_KEY)"
@@ -149,6 +153,8 @@ steps:
         export APIGEE_APP_ID="$(SANDBOX_APP_ID)"
         export STATUS_ENDPOINT_API_KEY="$(STATUS_ENDPOINT_API_KEY)"
         export SOURCE_COMMIT_ID="$(Build.SourceVersion)"
+        export NON_PROD_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(NON_PROD_PRIVATE_KEY)"
+        export NON_PROD_API_KEY="$(NON_PROD_API_KEY)"
         export INTEGRATION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(INTEGRATION_PRIVATE_KEY)"
         export INTEGRATION_API_KEY="$(INTEGRATION_API_KEY)"
         export PRODUCTION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(PRODUCTION_PRIVATE_KEY)"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1423,7 +1423,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1431,16 +1430,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1457,7 +1448,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1465,7 +1455,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1806,4 +1795,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d32acc2d6a0b58fb6d659041e91068cfa6e5c440b421499635f750dea6fc2a36"
+content-hash = "d11d48d7253d6c375f93adaa5e2d917cb1bfdd30909e105d34d32eb1384673a3"

--- a/proxies/shared/policies/AssignMessage.AuthenticationDetails.xml
+++ b/proxies/shared/policies/AssignMessage.AuthenticationDetails.xml
@@ -11,11 +11,7 @@
     <Properties/>
     <Set>
         <Headers>
-            {% if ENVIRONMENT_TYPE == 'internal' %}
-                <Header name="X-APIM-Application-Id">13bff444-4e1e-4e45-92a9-5924e2d19b9c</Header>
-            {% else %}
-                <Header name="X-APIM-Application-Id">{developer.app.id}</Header>
-            {% endif %}
+            <Header name="X-APIM-Application-Id">{developer.app.id}</Header>
         </Headers>
     </Set>
     <Remove>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["healthcare", "uk", "nhs", "communications", "email", "sms", "letter
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pytest-nhsd-apim = "^3.3.11"
+pytest-nhsd-apim = "^3.4.0"
 pytest-xdist = "^3.5.0"
 pre-commit = "^3.5.0"
 pytest-rerunfailures = "^12.0"

--- a/tests/development/content_types/test_406_errors.py
+++ b/tests/development/content_types/test_406_errors.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.constants import DEFAULT_CONTENT_TYPE, VALID_ENDPOINTS
 
 HEADER_NAME = ["accept", "ACCEPT", "Accept", "AcCePt"]
@@ -15,21 +16,20 @@ CORRELATION_IDS = [None, "88b10816-5d45-4992-bed0-ea685aaa0e1f"]
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_406(
     nhsd_apim_proxy_url,
+    bearer_token_internal_dev,
     accept_header_name,
     accept_header_value,
     correlation_id,
     method,
-    nhsd_apim_auth_headers,
     endpoints
 ):
     """
     .. include:: ../../partials/content_types/test_406.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         accept_header_name: accept_header_value,
         "X-Correlation-Id": correlation_id
     })

--- a/tests/development/content_types/test_415_errors.py
+++ b/tests/development/content_types/test_415_errors.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.constants import VALID_ENDPOINTS
 
 CONTENT_TYPE_NAME = ["content-type", "CONTENT_TYPE", "Content_Type", "conTENT_tYpe"]
@@ -15,21 +16,20 @@ CORRELATION_IDS = [None, "88b10816-5d45-4992-bed0-ea685aaa0e1f"]
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_415_invalid(
     nhsd_apim_proxy_url,
+    bearer_token_internal_dev,
     content_type_name,
     content_type_value,
     correlation_id,
     method,
-    nhsd_apim_auth_headers,
     endpoints
 ):
     """
     .. include:: ../../partials/content_types/test_415_invalid.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "Accept": "application/json",
         content_type_name: content_type_value,
         "X-Correlation-Id": correlation_id

--- a/tests/development/content_types/test_content_type_negotiation.py
+++ b/tests/development/content_types/test_content_type_negotiation.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib.constants.constants import METHODS, VALID_ENDPOINTS
+from lib.fixtures import *
 from lib import Error_Handler
 
 DEFAULT_CONTENT_TYPE = "application/vnd.api+json"
@@ -30,13 +31,12 @@ ACCEPT_HEADERS = [
 @pytest.mark.parametrize("accept_headers", ACCEPT_HEADERS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_application_response_type(nhsd_apim_proxy_url, accept_headers, method, nhsd_apim_auth_headers, endpoints):
+def test_application_response_type(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers, method, endpoints):
     """
     .. include:: ../../partials/content_types/test_application_response_type.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **accept_headers.get("headers")
     })
 

--- a/tests/development/content_types/test_missing_accept_header.py
+++ b/tests/development/content_types/test_missing_accept_header.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators, Error_Handler
+from lib.fixtures import *
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
 
 CORRELATION_IDS = [None, "88b10816-5d45-4992-bed0-ea685aaa0e1f"]
@@ -10,12 +11,11 @@ VALID_CONTENT_TYPE_HEADERS = ["application/json", "application/vnd.api+json"]
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize('content_type', VALID_CONTENT_TYPE_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_missing_accept_header(
     nhsd_apim_proxy_url,
+    bearer_token_internal_dev,
     correlation_id,
-    content_type,
-    nhsd_apim_auth_headers,
+    content_type
 ):
     """
     .. include:: ../../partials/content_types/test_missing_accept_header.rst
@@ -27,7 +27,7 @@ def test_missing_accept_header(
         headers={
             "Content-Type": content_type,
             "X-Correlation-Id": correlation_id,
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
         },
         json=data
     )

--- a/tests/development/headers/test_cors.py
+++ b/tests/development/headers/test_cors.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions
+from lib.fixtures import *
 from lib.constants.constants import VALID_ENDPOINTS
 
 
@@ -12,15 +13,14 @@ ORIGIN = "https://my.website"
 @pytest.mark.devtest
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_cors_options(nhsd_apim_proxy_url, method, nhsd_apim_auth_headers, endpoints):
+def test_cors_options(nhsd_apim_proxy_url, bearer_token_internal_dev, method, endpoints):
     """
     ..py:function:: test_cors_options
 
     .. include :: ../../partials/headers/test_cors_options.rst
     """
     resp = requests.options(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method
@@ -31,15 +31,14 @@ def test_cors_options(nhsd_apim_proxy_url, method, nhsd_apim_auth_headers, endpo
 @pytest.mark.devtest
 @pytest.mark.parametrize("method", TEST_METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_cors(nhsd_apim_proxy_url, method, nhsd_apim_auth_headers, endpoints):
+def test_cors(nhsd_apim_proxy_url, bearer_token_internal_dev, method, endpoints):
     """
     ..py:function:: test_cors
 
     .. include :: ../../partials/headers/test_cors.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "Accept": "*/*",
         "Origin": ORIGIN
     })

--- a/tests/development/headers/test_x_amz_removal.py
+++ b/tests/development/headers/test_x_amz_removal.py
@@ -2,17 +2,17 @@ import requests
 import pytest
 
 from lib import Assertions
+from lib.fixtures import *
 from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS
 
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method, nhsd_apim_auth_headers,):
+def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, bearer_token_internal_dev, endpoints, method,):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method

--- a/tests/development/headers/test_x_correlation_id.py
+++ b/tests/development/headers/test_x_correlation_id.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Error_Handler, Assertions
+from lib.fixtures import *
 from lib.constants.constants import VALID_ENDPOINTS
 
 
@@ -12,12 +13,11 @@ METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_request_with_x_correlation_id(
     nhsd_apim_proxy_url,
+    bearer_token_internal_dev,
     correlation_id,
     method,
-    nhsd_apim_auth_headers,
     endpoints
 ):
     """
@@ -26,7 +26,7 @@ def test_request_with_x_correlation_id(
     .. include:: ../../partials/headers/test_request_with_x_correlation_id.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "x-correlation-id": correlation_id
     })
 

--- a/tests/development/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/development/message_batches/create_message_batches/test_field_validation.py
@@ -2,6 +2,7 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Permutations, Generators
+from lib.fixtures import *
 import lib.constants.constants as constants
 from lib.constants.shared_paths import ROUTING_PLAN_ID_PATH
 from lib.constants.message_batches_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
@@ -16,15 +17,14 @@ headers = {
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_body(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_body(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_body.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -45,15 +45,14 @@ def test_invalid_body(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_header
     MISSING_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_property_missing(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_property_missing(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_message_batch_property_missing.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -77,15 +76,14 @@ def test_property_missing(nhsd_apim_proxy_url, property, pointer, correlation_id
     NULL_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_data_null(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_data_null(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_message_batch_null.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -109,15 +107,14 @@ def test_data_null(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_
     INVALID_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_data_invalid(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_data_invalid(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_message_batch_invalid.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -142,8 +139,7 @@ def test_data_invalid(nhsd_apim_proxy_url, property, pointer, correlation_id, nh
     DUPLICATE_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_data_duplicate(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_data_duplicate(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_data_duplicate.rst
     """
@@ -155,7 +151,7 @@ def test_data_duplicate(nhsd_apim_proxy_url, property, pointer, correlation_id, 
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -176,15 +172,14 @@ def test_data_duplicate(nhsd_apim_proxy_url, property, pointer, correlation_id, 
     TOO_FEW_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_data_too_few_items(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_data_too_few_items(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_data_too_few_items.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -206,13 +201,12 @@ def test_data_too_few_items(nhsd_apim_proxy_url, property, pointer, correlation_
 @pytest.mark.devtest
 @pytest.mark.parametrize("nhs_number", constants.INVALID_NHS_NUMBER)
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_nhs_number(nhsd_apim_proxy_url, nhs_number, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal_dev, nhs_number, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -245,13 +239,12 @@ def test_invalid_nhs_number(nhsd_apim_proxy_url, nhs_number, correlation_id, nhs
 @pytest.mark.devtest
 @pytest.mark.parametrize("dob", constants.INVALID_DOB)
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_dob(nhsd_apim_proxy_url, dob, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, dob, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -284,13 +277,12 @@ def test_invalid_dob(nhsd_apim_proxy_url, dob, correlation_id, nhsd_apim_auth_he
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -323,13 +315,12 @@ def test_invalid_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_aut
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_message_batch_reference(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_message_batch_reference(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_message_batch_reference.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -362,13 +353,12 @@ def test_invalid_message_batch_reference(nhsd_apim_proxy_url, correlation_id, nh
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_message_reference(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_message_reference(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -402,13 +392,12 @@ def test_invalid_message_reference(nhsd_apim_proxy_url, correlation_id, nhsd_api
 @pytest.mark.devtest
 @pytest.mark.parametrize("invalid_value", constants.INVALID_MESSAGE_VALUES)
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_blank_value_under_messages(nhsd_apim_proxy_url, invalid_value, correlation_id, nhsd_apim_auth_headers):
+def test_blank_value_under_messages(nhsd_apim_proxy_url, bearer_token_internal_dev, invalid_value, correlation_id):
     """
     .. include:: ../../partials/validation/test_blank_value_under_messages.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -434,13 +423,12 @@ def test_blank_value_under_messages(nhsd_apim_proxy_url, invalid_value, correlat
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_null_value_under_messages(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_null_value_under_messages(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_null_value_under_messages.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -467,13 +455,12 @@ def test_null_value_under_messages(nhsd_apim_proxy_url, correlation_id, nhsd_api
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", constants.INVALID_PERSONALISATION_VALUES)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_personalisation(nhsd_apim_proxy_url, correlation_id, personalisation, nhsd_apim_auth_headers):
+def test_invalid_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -507,13 +494,12 @@ def test_invalid_personalisation(nhsd_apim_proxy_url, correlation_id, personalis
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", constants.NULL_VALUES)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_null_personalisation(nhsd_apim_proxy_url, correlation_id, personalisation, nhsd_apim_auth_headers):
+def test_null_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={

--- a/tests/development/message_batches/create_message_batches/test_invalid_routing_plan.py
+++ b/tests/development/message_batches/create_message_batches/test_invalid_routing_plan.py
@@ -2,6 +2,7 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
 from lib.constants.constants import INVALID_ROUTING_PLAN
 from lib.constants.constants import DUPLICATE_ROUTING_PLAN_TEMPLATE_ID
@@ -11,13 +12,12 @@ from lib.constants.constants import CORRELATION_IDS
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_no_such_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_no_such_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {
@@ -49,13 +49,12 @@ def test_no_such_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_aut
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {
@@ -88,18 +87,17 @@ def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, correlatio
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("routing_plan_id", MISSING_TEMPLATE_ROUTING_PLANS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_routing_plan_missing_templates(
     nhsd_apim_proxy_url,
+    bearer_token_internal_dev,
     correlation_id,
-    routing_plan_id,
-    nhsd_apim_auth_headers
+    routing_plan_id
 ):
     """
     .. include:: ../../partials/invalid_routing_plans/test_500_missing_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {

--- a/tests/development/message_batches/create_message_batches/test_performance.py
+++ b/tests/development/message_batches/create_message_batches/test_performance.py
@@ -2,6 +2,7 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.constants import NUM_MAX_ERRORS
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
 
@@ -10,8 +11,7 @@ CONTENT_TYPE = "application/json"
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_create_messages_large_invalid_payload(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_create_messages_large_invalid_payload(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/performance/test_create_messages_large_valid_payload.rst
     """
@@ -29,7 +29,7 @@ def test_create_messages_large_invalid_payload(nhsd_apim_proxy_url, nhsd_apim_au
         })
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE
     }, json=data
@@ -39,8 +39,7 @@ def test_create_messages_large_invalid_payload(nhsd_apim_proxy_url, nhsd_apim_au
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_create_messages_large_not_unique_payload(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_create_messages_large_not_unique_payload(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/performance/test_create_messages_large_not_unique_payload.rst
     """
@@ -59,7 +58,7 @@ def test_create_messages_large_not_unique_payload(nhsd_apim_proxy_url, nhsd_apim
         })
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE
     }, json=data

--- a/tests/development/message_batches/create_message_batches/test_success.py
+++ b/tests/development/message_batches/create_message_batches/test_success.py
@@ -2,15 +2,15 @@ import requests
 import pytest
 import time
 from lib import Assertions, Generators
+from lib.fixtures import *
 import lib.constants.constants as constants
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
 
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("accept_headers", constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_201_message_batch_valid_accept_headers(
-    nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers
+    nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers
 ):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_accept_headers.rst
@@ -19,7 +19,7 @@ def test_201_message_batch_valid_accept_headers(
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -34,9 +34,8 @@ def test_201_message_batch_valid_accept_headers(
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("content_type", constants.VALID_CONTENT_TYPE_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_201_message_batch_valid_content_type_headers(
-    nhsd_apim_proxy_url, nhsd_apim_auth_headers, content_type
+    nhsd_apim_proxy_url, bearer_token_internal_dev, content_type
 ):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_content_type_headers.rst
@@ -45,7 +44,7 @@ def test_201_message_batch_valid_content_type_headers(
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": content_type,
         },
@@ -59,9 +58,9 @@ def test_201_message_batch_valid_content_type_headers(
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_201_message_batch_valid_nhs_number(
-    nhsd_apim_proxy_url, nhsd_apim_auth_headers
+    nhsd_apim_proxy_url,
+    bearer_token_internal_dev
 ):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_nhs_number.rst
@@ -74,7 +73,7 @@ def test_201_message_batch_valid_nhs_number(
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -89,8 +88,7 @@ def test_201_message_batch_valid_nhs_number(
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("dob", constants.VALID_DOB)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_201_message_batch_valid_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers, dob):
+def test_201_message_batch_valid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, dob):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_dob.rst
     """
@@ -100,7 +98,7 @@ def test_201_message_batch_valid_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -114,8 +112,7 @@ def test_201_message_batch_valid_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_request_without_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_request_without_dob(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_without_dob.rst
     """
@@ -125,7 +122,7 @@ def test_request_without_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -139,9 +136,9 @@ def test_request_without_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_201_message_batches_request_idempotency(
-    nhsd_apim_proxy_url, nhsd_apim_auth_headers
+    nhsd_apim_proxy_url,
+    bearer_token_internal_dev
 ):
     """
     .. include:: ../../partials/happy_path/test_201_message_batches_request_idempotency.rst
@@ -151,7 +148,7 @@ def test_201_message_batches_request_idempotency(
     respOne = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -163,7 +160,7 @@ def test_201_message_batches_request_idempotency(
     respTwo = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },

--- a/tests/development/messages/create_messages/test_field_validation.py
+++ b/tests/development/messages/create_messages/test_field_validation.py
@@ -2,6 +2,7 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Permutations, Generators
+from lib.fixtures import *
 import lib.constants.constants as constants
 from lib.constants.messages_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
     INVALID_PROPERTIES_PATHS, MESSAGES_ENDPOINT
@@ -16,15 +17,14 @@ CORRELATION_IDS = [None, "e8bb49c6-06bc-44f7-8443-9244284640f8"]
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_body(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_body(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_body.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -45,15 +45,14 @@ def test_invalid_body(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_header
     MISSING_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_property_missing(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_property_missing(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_messages_property_missing.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -77,15 +76,14 @@ def test_property_missing(nhsd_apim_proxy_url, property, pointer, correlation_id
     NULL_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_data_null(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_data_null(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_messages_null.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -109,15 +107,14 @@ def test_data_null(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_
     INVALID_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_data_invalid(nhsd_apim_proxy_url, property, pointer, correlation_id, nhsd_apim_auth_headers):
+def test_data_invalid(nhsd_apim_proxy_url, bearer_token_internal_dev, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_messages_invalid.rst
     """
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -139,13 +136,12 @@ def test_data_invalid(nhsd_apim_proxy_url, property, pointer, correlation_id, nh
 @pytest.mark.devtest
 @pytest.mark.parametrize("nhs_number", constants.INVALID_NHS_NUMBER)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_nhs_number(nhsd_apim_proxy_url, nhs_number, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal_dev, nhs_number, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -175,13 +171,12 @@ def test_invalid_nhs_number(nhsd_apim_proxy_url, nhs_number, correlation_id, nhs
 @pytest.mark.devtest
 @pytest.mark.parametrize("dob", constants.INVALID_DOB)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_dob(nhsd_apim_proxy_url, dob, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, dob, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -210,13 +205,12 @@ def test_invalid_dob(nhsd_apim_proxy_url, dob, correlation_id, nhsd_apim_auth_he
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -245,13 +239,12 @@ def test_invalid_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_aut
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_message_reference(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_invalid_message_reference(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -281,13 +274,12 @@ def test_invalid_message_reference(nhsd_apim_proxy_url, correlation_id, nhsd_api
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", constants.INVALID_PERSONALISATION_VALUES)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_invalid_personalisation(nhsd_apim_proxy_url, correlation_id, personalisation, nhsd_apim_auth_headers):
+def test_invalid_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -316,13 +308,12 @@ def test_invalid_personalisation(nhsd_apim_proxy_url, correlation_id, personalis
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", constants.NULL_VALUES)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_null_personalisation(nhsd_apim_proxy_url, correlation_id, personalisation, nhsd_apim_auth_headers):
+def test_null_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={

--- a/tests/development/messages/create_messages/test_invalid_routing_plan.py
+++ b/tests/development/messages/create_messages/test_invalid_routing_plan.py
@@ -2,6 +2,7 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
 from lib.constants.constants import INVALID_ROUTING_PLAN
 from lib.constants.constants import DUPLICATE_ROUTING_PLAN_TEMPLATE_ID
@@ -11,13 +12,12 @@ from lib.constants.constants import CORRELATION_IDS
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_no_such_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_no_such_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "X-Correlation-Id": correlation_id
         },
         json={
@@ -46,13 +46,12 @@ def test_no_such_routing_plan(nhsd_apim_proxy_url, correlation_id, nhsd_apim_aut
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, correlation_id, nhsd_apim_auth_headers):
+def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "X-Correlation-Id": correlation_id
         },
         json={
@@ -82,18 +81,17 @@ def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, correlatio
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("routing_plan_id", MISSING_TEMPLATE_ROUTING_PLANS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
 def test_routing_plan_missing_templates(
     nhsd_apim_proxy_url,
+    bearer_token_internal_dev,
     correlation_id,
-    routing_plan_id,
-    nhsd_apim_auth_headers
+    routing_plan_id
 ):
     """
     .. include:: ../../partials/invalid_routing_plans/test_500_missing_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {

--- a/tests/development/messages/create_messages/test_success.py
+++ b/tests/development/messages/create_messages/test_success.py
@@ -2,20 +2,20 @@ import requests
 import pytest
 import time
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
 import lib.constants.constants as constants
 
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_201_message_valid_accept_headers(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers):
+def test_201_message_valid_accept_headers(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_accept_headers.rst
     """
     data = Generators.generate_valid_create_message_body("dev")
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -26,14 +26,13 @@ def test_201_message_valid_accept_headers(nhsd_apim_proxy_url, nhsd_apim_auth_he
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('content_type', constants.VALID_CONTENT_TYPE_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_201_message_valid_content_type_headers(nhsd_apim_proxy_url, nhsd_apim_auth_headers, content_type):
+def test_201_message_valid_content_type_headers(nhsd_apim_proxy_url, bearer_token_internal_dev, content_type):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_content_type_headers.rst
     """
     data = Generators.generate_valid_create_message_body("dev")
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": content_type
         }, json=data
@@ -43,8 +42,7 @@ def test_201_message_valid_content_type_headers(nhsd_apim_proxy_url, nhsd_apim_a
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_201_message_valid_nhs_number(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_201_message_valid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_nhs_number.rst
     """
@@ -52,7 +50,7 @@ def test_201_message_valid_nhs_number(nhsd_apim_proxy_url, nhsd_apim_auth_header
     data["data"]["attributes"]["recipient"]["nhsNumber"] = constants.VALID_NHS_NUMBER
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -63,8 +61,7 @@ def test_201_message_valid_nhs_number(nhsd_apim_proxy_url, nhsd_apim_auth_header
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('dob', constants.VALID_DOB)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_201_message_valid_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers, dob):
+def test_201_message_valid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, dob):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_dob.rst
     """
@@ -72,7 +69,7 @@ def test_201_message_valid_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers, dob)
     data["data"]["attributes"]["recipient"]["dateOfBirth"] = dob
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -82,8 +79,7 @@ def test_201_message_valid_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers, dob)
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_request_without_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_request_without_dob(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_201_messages_without_dob.rst
     """
@@ -91,7 +87,7 @@ def test_request_without_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
     data["data"]["attributes"]["recipient"].pop("dateOfBirth")
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -101,15 +97,14 @@ def test_request_without_dob(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_201_message_request_idempotency(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_201_message_request_idempotency(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_201_messages_request_idempotency.rst
     """
     data = Generators.generate_valid_create_message_body("dev")
 
     respOne = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -118,7 +113,7 @@ def test_201_message_request_idempotency(nhsd_apim_proxy_url, nhsd_apim_auth_hea
     time.sleep(5)
 
     respTwo = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data

--- a/tests/development/messages/get_message/test_404.py
+++ b/tests/development/messages/get_message/test_404.py
@@ -1,19 +1,18 @@
 import requests
 import pytest
-import uuid
 from lib import Assertions, Generators
+from lib.fixtures import *
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_message_id_not_belonging_to_client_id(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_message_id_not_belonging_to_client_id(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/not_found/test_message_id_not_belonging_to_client_id.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/successful_email_other_owner",
-        headers=nhsd_apim_auth_headers
+        headers={"Authorization": bearer_token_internal_dev}
     )
     Assertions.assert_error_with_optional_correlation_id(
         resp,
@@ -24,14 +23,13 @@ def test_message_id_not_belonging_to_client_id(nhsd_apim_proxy_url, nhsd_apim_au
 
 
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_message_id_that_does_not_exist(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_message_id_that_does_not_exist(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/not_found/test_message_id_that_does_not_exist.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/does_not_exist",
-        headers=nhsd_apim_auth_headers
+        headers={"Authorization": bearer_token_internal_dev}
     )
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/development/messages/get_message/test_success.py
+++ b/tests/development/messages/get_message/test_success.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions
+from lib.fixtures import *
 import lib.constants.constants as constants
 from lib.constants.messages_paths import MESSAGES_ENDPOINT, MESSAGE_IDS, CHANNEL_TYPE, CHANNEL_STATUS
 
@@ -8,15 +9,14 @@ from lib.constants.messages_paths import MESSAGES_ENDPOINT, MESSAGE_IDS, CHANNEL
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
 @pytest.mark.parametrize('message_ids', MESSAGE_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_200_get_message(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers, message_ids):
+def test_200_get_message(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers, message_ids):
     """
     .. include:: ../../partials/happy_path/test_200_messages_message_id.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/{message_ids}",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -26,15 +26,14 @@ def test_200_get_message(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_hea
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_200_get_message_pending_enrichment(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers):
+def test_200_get_message_pending_enrichment(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_200_get_message_pending_enrichment.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/pending_enrichment_request_item_id",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -45,15 +44,14 @@ def test_200_get_message_pending_enrichment(nhsd_apim_proxy_url, nhsd_apim_auth_
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_200_get_message_sending(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers):
+def test_200_get_message_sending(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_200_get_message_sending.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/sending_nhsapp_request_item_id",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -64,15 +62,14 @@ def test_200_get_message_sending(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ac
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_200_get_message_successful(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers):
+def test_200_get_message_successful(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_200_get_message_successful.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/successful_letter_request_item_id",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -83,15 +80,14 @@ def test_200_get_message_successful(nhsd_apim_proxy_url, nhsd_apim_auth_headers,
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_200_get_message_failed(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers):
+def test_200_get_message_failed(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_200_get_message_failed.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/exit_code_request_item_id",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -102,15 +98,14 @@ def test_200_get_message_failed(nhsd_apim_proxy_url, nhsd_apim_auth_headers, acc
 
 @pytest.mark.devtest
 @pytest.mark.parametrize('accept_headers', constants.VALID_ACCEPT_HEADERS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_200_get_message_cascade(nhsd_apim_proxy_url, nhsd_apim_auth_headers, accept_headers):
+def test_200_get_message_cascade(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_200_get_message_cascade.rst
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/cascade_sending_all_status_request_item_id",
         headers={
-            **nhsd_apim_auth_headers,
+            "Authorization": bearer_token_internal_dev,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },

--- a/tests/development/nhsapp_accounts/test_400.py
+++ b/tests/development/nhsapp_accounts/test_400.py
@@ -4,19 +4,19 @@ from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     VALID_MULTI_PAGE_NUMBERS, INVALID_ODS_CODES, CORRELATION_IDS, LIVE_ODS_CODES, INVALID_PAGES
+from lib.fixtures import *
 
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("page", VALID_MULTI_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_400_missing_ods_code(nhsd_apim_proxy_url, nhsd_apim_auth_headers, page, correlation_id):
+def test_400_missing_ods_code(nhsd_apim_proxy_url, bearer_token_internal_dev, page, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_missing_ods_code.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -34,14 +34,13 @@ def test_400_missing_ods_code(nhsd_apim_proxy_url, nhsd_apim_auth_headers, page,
 @pytest.mark.devtest
 @pytest.mark.parametrize("ods_code", INVALID_ODS_CODES)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_400_invalid_ods_code(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_code, correlation_id):
+def test_400_invalid_ods_code(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_ods_code.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -60,14 +59,13 @@ def test_400_invalid_ods_code(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_c
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", INVALID_PAGES)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_400_invalid_page(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_code, page, correlation_id):
+def test_400_invalid_page(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/invalid_page/test_400_nhsapp_accounts_invalid_page.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_404.py
+++ b/tests/development/nhsapp_accounts/test_404.py
@@ -4,6 +4,7 @@ from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     LIVE_ODS_CODES, CORRELATION_IDS
+from lib.fixtures import *
 
 REPORT_NOT_FOUND_PAGE_NUMBERS = [1000, 2000, 3000]
 NOT_FOUND_ODS_CODE = 'T00404'
@@ -13,14 +14,13 @@ NOT_FOUND_ODS_CODE = 'T00404'
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", REPORT_NOT_FOUND_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_404_page_not_found(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_code, page, correlation_id):
+def test_404_page_not_found(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_page_not_found.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -38,14 +38,13 @@ def test_404_page_not_found(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_cod
 
 @pytest.mark.sandboxtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_404_report_not_found(nhsd_apim_proxy_url, nhsd_apim_auth_headers, correlation_id):
+def test_404_report_not_found(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
 
     """
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_report_not_found.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_429.py
+++ b/tests/development/nhsapp_accounts/test_429.py
@@ -4,20 +4,20 @@ from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     SINGLE_PAGE_ODS_CODES, CORRELATION_IDS
+from lib.fixtures import *
 
 TOO_MANY_REQUESTS_ODS_CODE = 'T00429'
 
 
 @pytest.mark.sandboxtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_429_too_many_requests(nhsd_apim_proxy_url, nhsd_apim_auth_headers, correlation_id):
+def test_429_too_many_requests(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
 
     """
     .. include:: ../../partials/too_many_requests/test_429_nhs_app_accounts_too_many_requests.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_502.py
+++ b/tests/development/nhsapp_accounts/test_502.py
@@ -4,20 +4,20 @@ from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     SINGLE_PAGE_ODS_CODES, CORRELATION_IDS
+from lib.fixtures import *
 
 BAD_GATEWAY_ODS_CODE = 'T00401'  # The mock for the NHS App API will return a 401 should cause the BE to return a 502
 
 
 @pytest.mark.sandboxtest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_502_bad_gateway(nhsd_apim_proxy_url, nhsd_apim_auth_headers, correlation_id):
+def test_502_bad_gateway(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
 
     """
     .. include:: ../../partials/bad_gatway/test_502_bad_gateway.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_success.py
+++ b/tests/development/nhsapp_accounts/test_success.py
@@ -4,20 +4,20 @@ from lib import Assertions, Generators
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     LIVE_ODS_CODES, CORRELATION_IDS, VALID_MULTI_PAGE_NUMBERS, \
     MULTI_LAST_PAGE, VALID_SINGLE_PAGE_NUMBERS
+from lib.fixtures import *
 
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", VALID_SINGLE_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_single_page(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_code, page, correlation_id):
+def test_single_page(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_single_page.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -33,14 +33,13 @@ def test_single_page(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_code, page
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", VALID_MULTI_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_multi_pages(nhsd_apim_proxy_url, nhsd_apim_auth_headers, ods_code, page, correlation_id):
+def test_multi_pages(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_multi_pages.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/test_404_errors.py
+++ b/tests/development/test_404_errors.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators
+from lib.fixtures import *
 
 POST_PATHS = ["/v1/ignore/i-dont-exist", "/api/fake-endpoint", "/im-a-teapot"]
 CORRELATION_IDS = [None, "228aac39-542d-4803-b28e-5de9e100b9f8"]
@@ -11,13 +12,12 @@ METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
 @pytest.mark.parametrize("request_path", POST_PATHS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_404_not_found(nhsd_apim_proxy_url, request_path, correlation_id, method, nhsd_apim_auth_headers):
+def test_404_not_found(nhsd_apim_proxy_url, bearer_token_internal_dev, request_path, correlation_id, method):
     """
     .. include:: ../../partials/not_found/test_404_not_found.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{request_path}", headers={
-        **nhsd_apim_auth_headers,
+        "Authorization": bearer_token_internal_dev,
         "X-Correlation-Id": correlation_id,
         "Accept": "*/*",
         "Content-Type": "application/json"

--- a/tests/end_to_end/test_email.py
+++ b/tests/end_to_end/test_email.py
@@ -1,19 +1,19 @@
 import pytest
 import os
-from lib import Assertions, Generators, Helper
+from lib import Assertions, Helper, Generators
+from lib.fixtures import *
 from notifications_python_client.notifications import NotificationsAPIClient
 
 
 @pytest.mark.e2e
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_email_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_email_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_email_end_to_end_internal_dev.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
+        {"Authorization": bearer_token_internal_dev},
         Generators.generate_send_message_body("email", "internal-dev")
     )
 
@@ -21,7 +21,7 @@ def test_email_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_heade
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id
     )
 
@@ -33,14 +33,13 @@ def test_email_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_heade
 
 @pytest.mark.e2e
 @pytest.mark.uattest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_email_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_email_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_email_end_to_end_uat.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
+        {"Authorization": bearer_token_internal_dev},
         Generators.generate_send_message_body("email", "internal-qa")
     )
 
@@ -48,7 +47,7 @@ def test_email_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id
     )
 

--- a/tests/end_to_end/test_letter.py
+++ b/tests/end_to_end/test_letter.py
@@ -1,62 +1,65 @@
 import pytest
 import os
 from lib import Assertions, Generators, Helper
+from lib.fixtures import *
 from notifications_python_client.notifications import NotificationsAPIClient
 
 
 @pytest.mark.e2e
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_letter_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_letter_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_letter_end_to_end_internal_dev.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
-        Generators.generate_send_message_body("letter", "internal-dev")
+        {"Authorization": bearer_token_internal_dev},
+        Generators.generate_send_message_body("letter", "internal-dev"),
     )
 
     message_id = resp.json().get("data").get("id")
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id,
         end_state="sending",
-        poll_time=595
+        poll_time=595,
     )
 
     notifications_client = NotificationsAPIClient(os.environ.get("GUKN_API_KEY"))
-    gov_uk_response = notifications_client.get_all_notifications("received").get("notifications")
+    gov_uk_response = notifications_client.get_all_notifications("received").get(
+        "notifications"
+    )
 
     Assertions.assert_letter_gov_uk(gov_uk_response, message_id)
 
 
 @pytest.mark.e2e
 @pytest.mark.uattest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_letter_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_letter_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_letter_end_to_end_uat.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
-        Generators.generate_send_message_body("letter", "internal-qa")
+        {"Authorization": bearer_token_internal_dev},
+        Generators.generate_send_message_body("letter", "internal-qa"),
     )
 
     message_id = resp.json().get("data").get("id")
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id,
         end_state="sending",
-        poll_time=595
+        poll_time=595,
     )
 
     notifications_client = NotificationsAPIClient(os.environ.get("UAT_GUKN_API_KEY"))
-    gov_uk_response = notifications_client.get_all_notifications("received").get("notifications")
+    gov_uk_response = notifications_client.get_all_notifications("received").get(
+        "notifications"
+    )
 
     Assertions.assert_letter_gov_uk(gov_uk_response, message_id)

--- a/tests/end_to_end/test_nhsapp.py
+++ b/tests/end_to_end/test_nhsapp.py
@@ -1,18 +1,18 @@
 import pytest
 import uuid
 from lib import Assertions, Generators, Helper
+from lib.fixtures import *
 
 
 @pytest.mark.e2e
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_nhsapp_end_to_end(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_nhsapp_end_to_end(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_nhsapp_end_to_end_internal_dev.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
+        {"Authorization": bearer_token_internal_dev},
         Generators.generate_send_message_body("nhsapp", "internal-dev")
     )
 
@@ -20,18 +20,23 @@ def test_nhsapp_end_to_end(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id
     )
 
     Assertions.assert_get_message_status(
-        Helper.get_message(nhsd_apim_proxy_url, nhsd_apim_auth_headers, message_id), "delivered")
+        Helper.get_message(
+            nhsd_apim_proxy_url,
+            {"Authorization": bearer_token_internal_dev},
+            message_id
+        ),
+        "delivered"
+    )
 
 
 @pytest.mark.e2e
 @pytest.mark.uattest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_nhsapp_end_to_end_uat.rst
     """
@@ -39,7 +44,7 @@ def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
+        {"Authorization": bearer_token_internal_dev},
         Generators.generate_send_message_body("nhsapp", "internal-qa", personalisation)
     )
 
@@ -47,12 +52,18 @@ def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id,
         end_state="sending"
     )
 
     Assertions.assert_get_message_status(
-        Helper.get_message(nhsd_apim_proxy_url, nhsd_apim_auth_headers, message_id), "sending")
+        Helper.get_message(
+            nhsd_apim_proxy_url,
+            {"Authorization": bearer_token_internal_dev},
+            message_id
+        ),
+        "sending"
+    )
 
     Helper.nhs_app_login_and_view_message(personalisation)

--- a/tests/end_to_end/test_sms.py
+++ b/tests/end_to_end/test_sms.py
@@ -1,19 +1,19 @@
 import pytest
 import os
 from lib import Assertions, Generators, Helper
+from lib.fixtures import *
 from notifications_python_client.notifications import NotificationsAPIClient
 
 
 @pytest.mark.e2e
 @pytest.mark.devtest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_sms_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_sms_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_sms_end_to_end_internal_dev.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
+        {"Authorization": bearer_token_internal_dev},
         Generators.generate_send_message_body("sms", "internal-dev")
     )
 
@@ -21,7 +21,7 @@ def test_sms_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_headers
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id
     )
 
@@ -33,14 +33,13 @@ def test_sms_end_to_end_internal_dev(nhsd_apim_proxy_url, nhsd_apim_auth_headers
 
 @pytest.mark.e2e
 @pytest.mark.uattest
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_sms_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
+def test_sms_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_sms_end_to_end_uat.rst
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        nhsd_apim_auth_headers,
+        {"Authorization": bearer_token_internal_dev},
         Generators.generate_send_message_body("sms", "internal-qa")
     )
 
@@ -48,7 +47,7 @@ def test_sms_end_to_end_uat(nhsd_apim_proxy_url, nhsd_apim_auth_headers):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth=nhsd_apim_auth_headers,
+        auth={"Authorization": bearer_token_internal_dev},
         message_id=message_id
     )
 

--- a/tests/integration/content_types/test_406_errors.py
+++ b/tests/integration/content_types/test_406_errors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import CORRELATION_IDS, METHODS, INT_URL, DEFAULT_CONTENT_TYPE, VALID_ENDPOINTS
+from lib.fixtures import *
 
 HEADER_NAME = ["accept", "ACCEPT", "Accept", "AcCePt"]
 HEADER_VALUE = ["", "application/xml", "image/png", "text/plain", "audio/mpeg", "xyz/abc"]
@@ -14,6 +15,7 @@ HEADER_VALUE = ["", "application/xml", "image/png", "text/plain", "audio/mpeg", 
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_406(
+    bearer_token_int,
     accept_header_name,
     accept_header_value,
     correlation_id,
@@ -26,7 +28,7 @@ def test_406(
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
         accept_header_name: accept_header_value,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int,
     })
 
     Assertions.assert_error_with_optional_correlation_id(

--- a/tests/integration/content_types/test_415_errors.py
+++ b/tests/integration/content_types/test_415_errors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import INT_URL, CORRELATION_IDS, VALID_ENDPOINTS
+from lib.fixtures import *
 
 CONTENT_TYPE_NAME = ["content-type", "CONTENT_TYPE", "Content_Type", "conTENT_tYpe"]
 CONTENT_TYPE_VALUE = ["", "application/xml", "image/png", "text/plain", "audio/mpeg", "xyz/abc"]
@@ -15,6 +16,7 @@ METHODS = ["post", "put", "patch"]
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 def test_415_invalid(
+    bearer_token_int,
     content_type_name,
     content_type_value,
     correlation_id,
@@ -25,7 +27,7 @@ def test_415_invalid(
     .. include:: ../../partials/content_types/test_415_invalid.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         "Accept": "application/json",
         content_type_name: content_type_value,
         "X-Correlation-Id": correlation_id

--- a/tests/integration/content_types/test_content_type_negotiation.py
+++ b/tests/integration/content_types/test_content_type_negotiation.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Authentication, Error_Handler
+from lib import Error_Handler
 from lib.constants.constants import INT_URL, METHODS, VALID_ENDPOINTS
+from lib.fixtures import *
 
 DEFAULT_CONTENT_TYPE = "application/vnd.api+json"
 ACCEPT_HEADERS = [
@@ -30,12 +31,12 @@ ACCEPT_HEADERS = [
 @pytest.mark.parametrize("accept_headers", ACCEPT_HEADERS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_application_response_type(accept_headers, method, endpoints):
+def test_application_response_type(bearer_token_int, accept_headers, method, endpoints):
     """
     .. include:: ../../partials/content_types/test_application_response_type.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         **accept_headers.get("headers")
     })
 

--- a/tests/integration/headers/test_cors.py
+++ b/tests/integration/headers/test_cors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Authentication
+from lib import Assertions
 from lib.constants.constants import INT_URL, VALID_ENDPOINTS, ORIGIN
+from lib.fixtures import *
 
 METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 TEST_METHODS = ["get", "post", "put", "delete"]
@@ -10,12 +11,12 @@ TEST_METHODS = ["get", "post", "put", "delete"]
 @pytest.mark.inttest
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_cors_options(method, endpoints):
+def test_cors_options(bearer_token_int, method, endpoints):
     """
     .. include :: ../../partials/headers/test_cors_options.rst
     """
     resp = requests.options(f"{INT_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method
@@ -26,12 +27,12 @@ def test_cors_options(method, endpoints):
 @pytest.mark.inttest
 @pytest.mark.parametrize("method", TEST_METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_cors(method, endpoints):
+def test_cors(bearer_token_int, method, endpoints):
     """
     .. include :: ../../partials/headers/test_cors.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         "Accept": "*/*",
         "Origin": ORIGIN
     })

--- a/tests/integration/headers/test_x_amz_removal.py
+++ b/tests/integration/headers/test_x_amz_removal.py
@@ -1,17 +1,18 @@
 import requests
 import pytest
 
-from lib import Assertions, Authentication
+from lib import Assertions
 from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS, INT_URL
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_request_with_x_amz_is_removed(endpoints, method):
+def test_request_with_x_amz_is_removed(bearer_token_int, endpoints, method):
 
     resp = getattr(requests, method)(f"{INT_URL}/{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method

--- a/tests/integration/headers/test_x_correlation_id.py
+++ b/tests/integration/headers/test_x_correlation_id.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Authentication, Error_Handler, Assertions
+from lib import Assertions, Error_Handler
 from lib.constants.constants import INT_URL, METHODS, VALID_ENDPOINTS
+from lib.fixtures import *
 
 CORRELATION_IDS = [None, "a17669c8-219a-11ee-ba86-322b0407c489"]
 
@@ -10,12 +11,12 @@ CORRELATION_IDS = [None, "a17669c8-219a-11ee-ba86-322b0407c489"]
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_request_with_x_correlation_id(correlation_id, method, endpoints):
+def test_request_with_x_correlation_id(bearer_token_int, correlation_id, method, endpoints):
     """
     .. include:: ../../partials/headers/test_request_with_x_correlation_id.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         "x-correlation-id": correlation_id
     })
 

--- a/tests/integration/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/integration/message_batches/create_message_batches/test_field_validation.py
@@ -1,11 +1,12 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Permutations, Generators, Authentication
+from lib import Assertions, Permutations, Generators
 import lib.constants.constants as constants
 from lib.constants.message_batches_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
     INVALID_PROPERTIES_PATHS, DUPLICATE_PROPERTIES_PATHS, TOO_FEW_PROPERTIES_PATHS, MESSAGE_BATCH_REFERENCE_PATH, \
     FIRST_MESSAGE_RECIPIENT_NHSNUMBER_PATH, FIRST_MESSAGE_REFERENCE_PATH, MESSAGE_BATCHES_ENDPOINT, ROUTING_PLAN_ID_PATH
+from lib.fixtures import *
 headers = {
     "Accept": "application/json",
     "Content-Type": "application/json"
@@ -14,7 +15,7 @@ headers = {
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_invalid_body(correlation_id):
+def test_invalid_body(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_body.rst
     """
@@ -23,7 +24,7 @@ def test_invalid_body(correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         data="{}SF{}NOTVALID",
     )
@@ -42,7 +43,7 @@ def test_invalid_body(correlation_id):
     MISSING_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_property_missing(property, pointer, correlation_id):
+def test_property_missing(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_message_batch_property_missing.rst
     """
@@ -51,7 +52,7 @@ def test_property_missing(property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json=Permutations.new_dict_without_key(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -73,7 +74,7 @@ def test_property_missing(property, pointer, correlation_id):
     NULL_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_data_null(property, pointer, correlation_id):
+def test_data_null(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_message_batch_null.rst
     """
@@ -82,7 +83,7 @@ def test_data_null(property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json=Permutations.new_dict_with_null_key(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -104,7 +105,7 @@ def test_data_null(property, pointer, correlation_id):
     INVALID_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_data_invalid(property, pointer, correlation_id):
+def test_data_invalid(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_message_batch_invalid.rst
     """
@@ -113,7 +114,7 @@ def test_data_invalid(property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -136,7 +137,7 @@ def test_data_invalid(property, pointer, correlation_id):
     DUPLICATE_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_data_duplicate(property, pointer, correlation_id):
+def test_data_duplicate(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_data_duplicate.rst
     """
@@ -150,7 +151,7 @@ def test_data_duplicate(property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json=data,
     )
@@ -169,7 +170,7 @@ def test_data_duplicate(property, pointer, correlation_id):
     TOO_FEW_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_data_too_few_items(property, pointer, correlation_id):
+def test_data_too_few_items(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_data_too_few_items.rst
     """
@@ -178,7 +179,7 @@ def test_data_too_few_items(property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -198,14 +199,14 @@ def test_data_too_few_items(property, pointer, correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("nhs_number", constants.INVALID_NHS_NUMBER)
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_invalid_nhs_number(nhs_number, correlation_id):
+def test_invalid_nhs_number(bearer_token_int, nhs_number, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -237,14 +238,14 @@ def test_invalid_nhs_number(nhs_number, correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("dob", constants.INVALID_DOB)
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_invalid_dob(dob, correlation_id):
+def test_invalid_dob(bearer_token_int, dob, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -275,14 +276,14 @@ def test_invalid_dob(dob, correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_invalid_routing_plan(correlation_id):
+def test_invalid_routing_plan(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -313,14 +314,14 @@ def test_invalid_routing_plan(correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_invalid_message_batch_reference(correlation_id):
+def test_invalid_message_batch_reference(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_message_batch_reference.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -351,14 +352,14 @@ def test_invalid_message_batch_reference(correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_invalid_message_reference(correlation_id):
+def test_invalid_message_reference(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -390,14 +391,14 @@ def test_invalid_message_reference(correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("invalid_value", constants.INVALID_MESSAGE_VALUES)
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_blank_value_under_messages(invalid_value, correlation_id):
+def test_blank_value_under_messages(bearer_token_int, invalid_value, correlation_id):
     """
     .. include:: ../../partials/validation/test_blank_value_under_messages.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -421,14 +422,14 @@ def test_blank_value_under_messages(invalid_value, correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
-def test_null_value_under_messages(correlation_id):
+def test_null_value_under_messages(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_null_value_under_messages.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -453,14 +454,14 @@ def test_null_value_under_messages(correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", constants.INVALID_PERSONALISATION_VALUES)
-def test_invalid_personalisation(correlation_id, personalisation):
+def test_invalid_personalisation(bearer_token_int, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -492,14 +493,14 @@ def test_invalid_personalisation(correlation_id, personalisation):
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", constants.NULL_VALUES)
-def test_null_personalisation(correlation_id, personalisation):
+def test_null_personalisation(bearer_token_int, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json={
         "data": {
             "type": "MessageBatch",

--- a/tests/integration/message_batches/create_message_batches/test_invalid_routing_plan.py
+++ b/tests/integration/message_batches/create_message_batches/test_invalid_routing_plan.py
@@ -1,9 +1,10 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 CORRELATION_IDS = [None, "228aac39-542d-4803-b28e-5de9e100b9f8"]
 METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
@@ -16,14 +17,14 @@ headers = {
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_no_such_routing_plan(correlation_id):
+def test_no_such_routing_plan(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         }, json={
         "data": {
             "type": "MessageBatch",
@@ -54,14 +55,14 @@ def test_no_such_routing_plan(correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_routing_plan_not_belonging_to_client_id(correlation_id):
+def test_routing_plan_not_belonging_to_client_id(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         }, json={
         "data": {
             "type": "MessageBatch",
@@ -93,13 +94,13 @@ def test_routing_plan_not_belonging_to_client_id(correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("routing_plan_id", constants.MISSING_TEMPLATE_ROUTING_PLANS)
-def test_routing_plan_missing_templates(correlation_id, routing_plan_id,):
+def test_routing_plan_missing_templates(bearer_token_int, correlation_id, routing_plan_id,):
     """
     .. include:: ../../partials/invalid_routing_plans/test_500_missing_routing_plan.rst
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('int')}",
+            "Authorization": bearer_token_int,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {

--- a/tests/integration/message_batches/create_message_batches/test_performance.py
+++ b/tests/integration/message_batches/create_message_batches/test_performance.py
@@ -1,16 +1,17 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import NUM_MAX_ERRORS, INT_URL
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 NUM_MESSAGES = 50000
 CONTENT_TYPE = "application/json"
 
 
 @pytest.mark.inttest
-def test_create_messages_large_invalid_payload():
+def test_create_messages_large_invalid_payload(bearer_token_int):
     """
     .. include:: ../../partials/performance/test_create_messages_large_valid_payload.rst
     """
@@ -30,7 +31,7 @@ def test_create_messages_large_invalid_payload():
     resp = requests.post(f"{INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)
@@ -38,7 +39,7 @@ def test_create_messages_large_invalid_payload():
 
 
 @pytest.mark.inttest
-def test_create_messages_large_not_unique_payload():
+def test_create_messages_large_not_unique_payload(bearer_token_int):
     """
     .. include:: ../../partials/performance/test_create_messages_large_not_unique_payload.rst
     """
@@ -59,7 +60,7 @@ def test_create_messages_large_not_unique_payload():
     resp = requests.post(f"{INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE,
-        "Authorization": f"{Authentication.generate_authentication('int')}"
+        "Authorization": bearer_token_int
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)

--- a/tests/integration/message_batches/create_message_batches/test_success.py
+++ b/tests/integration/message_batches/create_message_batches/test_success.py
@@ -1,14 +1,15 @@
 import requests
 import pytest
 import time
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("accept_headers", constants.VALID_ACCEPT_HEADERS)
-def test_201_message_batch_valid_accept_headers(accept_headers):
+def test_201_message_batch_valid_accept_headers(bearer_token_int, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_accept_headers.rst
     """
@@ -17,7 +18,7 @@ def test_201_message_batch_valid_accept_headers(accept_headers):
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": accept_headers,
             "Content-Type": "application/json",
         },
@@ -32,7 +33,7 @@ def test_201_message_batch_valid_accept_headers(accept_headers):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("content_type", constants.VALID_CONTENT_TYPE_HEADERS)
-def test_201_message_batch_valid_content_type_headers(content_type):
+def test_201_message_batch_valid_content_type_headers(bearer_token_int, content_type):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_content_type_headers.rst
     """
@@ -41,7 +42,7 @@ def test_201_message_batch_valid_content_type_headers(content_type):
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": content_type,
         },
@@ -55,7 +56,7 @@ def test_201_message_batch_valid_content_type_headers(content_type):
 
 
 @pytest.mark.inttest
-def test_201_message_batch_valid_nhs_number():
+def test_201_message_batch_valid_nhs_number(bearer_token_int):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_nhs_number.rst
     """
@@ -64,7 +65,7 @@ def test_201_message_batch_valid_nhs_number():
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -79,7 +80,7 @@ def test_201_message_batch_valid_nhs_number():
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("dob", constants.VALID_DOB)
-def test_201_message_batch_valid_dob(dob):
+def test_201_message_batch_valid_dob(bearer_token_int, dob):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_dob.rst
     """
@@ -89,7 +90,7 @@ def test_201_message_batch_valid_dob(dob):
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -103,7 +104,7 @@ def test_201_message_batch_valid_dob(dob):
 
 
 @pytest.mark.inttest
-def test_request_without_dob():
+def test_request_without_dob(bearer_token_int):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_without_dob.rst
     """
@@ -113,7 +114,7 @@ def test_request_without_dob():
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -127,7 +128,7 @@ def test_request_without_dob():
 
 
 @pytest.mark.inttest
-def test_201_message_batches_request_idempotency():
+def test_201_message_batches_request_idempotency(bearer_token_int):
     """
     .. include:: ../../partials/happy_path/test_201_message_batches_request_idempotency.rst
     """
@@ -136,7 +137,7 @@ def test_201_message_batches_request_idempotency():
     respOne = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -148,7 +149,7 @@ def test_201_message_batches_request_idempotency():
     respTwo = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },

--- a/tests/integration/messages/create_messages/test_field_validation.py
+++ b/tests/integration/messages/create_messages/test_field_validation.py
@@ -1,11 +1,12 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Permutations, Generators, Authentication
+from lib import Assertions, Permutations, Generators
 from lib.constants.constants import INT_URL, INVALID_NHS_NUMBER, INVALID_DOB, \
     INVALID_PERSONALISATION_VALUES, NULL_VALUES, CORRELATION_IDS
 from lib.constants.messages_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
     INVALID_PROPERTIES_PATHS, MESSAGES_ENDPOINT
+from lib.fixtures import *
 
 
 headers = {
@@ -16,14 +17,14 @@ headers = {
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_invalid_body(correlation_id):
+def test_invalid_body(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_body.rst
     """
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -44,14 +45,14 @@ def test_invalid_body(correlation_id):
     MISSING_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_property_missing(property, pointer, correlation_id):
+def test_property_missing(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_messages_property_missing.rst
     """
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -75,14 +76,14 @@ def test_property_missing(property, pointer, correlation_id):
     NULL_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_data_null(property, pointer, correlation_id):
+def test_data_null(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_messages_null.rst
     """
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -106,14 +107,14 @@ def test_data_null(property, pointer, correlation_id):
     INVALID_PROPERTIES_PATHS
 )
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_data_invalid(property, pointer, correlation_id):
+def test_data_invalid(bearer_token_int, property, pointer, correlation_id):
     """
     .. include:: ../../partials/validation/test_messages_invalid.rst
     """
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -135,12 +136,12 @@ def test_data_invalid(property, pointer, correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("nhs_number", INVALID_NHS_NUMBER)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_invalid_nhs_number(nhs_number, correlation_id):
+def test_invalid_nhs_number(bearer_token_int, nhs_number, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -170,12 +171,12 @@ def test_invalid_nhs_number(nhs_number, correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("dob", INVALID_DOB)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_invalid_dob(dob, correlation_id):
+def test_invalid_dob(bearer_token_int, dob, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -204,12 +205,12 @@ def test_invalid_dob(dob, correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_invalid_routing_plan(correlation_id):
+def test_invalid_routing_plan(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -238,12 +239,12 @@ def test_invalid_routing_plan(correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_invalid_message_reference(correlation_id):
+def test_invalid_message_reference(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -273,12 +274,12 @@ def test_invalid_message_reference(correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", INVALID_PERSONALISATION_VALUES)
-def test_invalid_personalisation(correlation_id, personalisation):
+def test_invalid_personalisation(bearer_token_int, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -307,12 +308,12 @@ def test_invalid_personalisation(correlation_id, personalisation):
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("personalisation", NULL_VALUES)
-def test_null_personalisation(correlation_id, personalisation):
+def test_null_personalisation(bearer_token_int, correlation_id, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={

--- a/tests/integration/messages/create_messages/test_invalid_routing_plan.py
+++ b/tests/integration/messages/create_messages/test_invalid_routing_plan.py
@@ -1,13 +1,14 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
 from lib.constants.constants import DUPLICATE_ROUTING_PLAN_TEMPLATE_ID
 from lib.constants.constants import MISSING_TEMPLATE_ROUTING_PLANS
 from lib.constants.constants import INVALID_ROUTING_PLAN
 from lib.constants.constants import CORRELATION_IDS
 from lib.constants.constants import INT_URL
+from lib.fixtures import *
 
 headers = {
     "Accept": "application/json",
@@ -17,14 +18,14 @@ headers = {
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_no_such_routing_plan(correlation_id):
+def test_no_such_routing_plan(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json={
             "data": {
@@ -52,14 +53,14 @@ def test_no_such_routing_plan(correlation_id):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_routing_plan_not_belonging_to_client_id(correlation_id):
+def test_routing_plan_not_belonging_to_client_id(bearer_token_int, correlation_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         },
         json={
             "data": {
@@ -88,15 +89,14 @@ def test_routing_plan_not_belonging_to_client_id(correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("routing_plan_id", MISSING_TEMPLATE_ROUTING_PLANS)
-@pytest.mark.nhsd_apim_authorization({"access": "application", "level": "level3"})
-def test_routing_plan_missing_templates(correlation_id, routing_plan_id):
+def test_routing_plan_missing_templates(bearer_token_int, correlation_id, routing_plan_id):
     """
     .. include:: ../../partials/invalid_routing_plans/test_500_missing_routing_plan.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": f"{Authentication.generate_authentication('int')}"
+            "Authorization": bearer_token_int
         }, json={
         "data": {
             "type": "Message",

--- a/tests/integration/messages/create_messages/test_success.py
+++ b/tests/integration/messages/create_messages/test_success.py
@@ -1,15 +1,16 @@
 import requests
 import pytest
 import time
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import INT_URL, VALID_CONTENT_TYPE_HEADERS, VALID_ACCEPT_HEADERS, \
     VALID_NHS_NUMBER, VALID_DOB, VALID_ROUTING_PLAN_ID_INT
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
 @pytest.mark.parametrize('accept_headers', VALID_ACCEPT_HEADERS)
-def test_201_single_message_with_valid_accept_headers(accept_headers):
+def test_201_single_message_with_valid_accept_headers(bearer_token_int, accept_headers):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_accept_headers.rst
     """
@@ -17,7 +18,7 @@ def test_201_single_message_with_valid_accept_headers(accept_headers):
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -28,13 +29,13 @@ def test_201_single_message_with_valid_accept_headers(accept_headers):
 
 @pytest.mark.inttest
 @pytest.mark.parametrize('content_type', VALID_CONTENT_TYPE_HEADERS)
-def test_201_single_message_with_valid_content_type_headers(content_type):
+def test_201_single_message_with_valid_content_type_headers(bearer_token_int, content_type):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_content_type_headers.rst
     """
     data = Generators.generate_valid_create_message_body("int")
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": content_type
         }, json=data
@@ -43,7 +44,7 @@ def test_201_single_message_with_valid_content_type_headers(content_type):
 
 
 @pytest.mark.inttest
-def test_201_single_message_with_valid_nhs_number():
+def test_201_single_message_with_valid_nhs_number(bearer_token_int):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_nhs_number.rst
     """
@@ -51,7 +52,7 @@ def test_201_single_message_with_valid_nhs_number():
     data["data"]["attributes"]["recipient"]["nhsNumber"] = VALID_NHS_NUMBER
 
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json"
         }, json=data
@@ -61,7 +62,7 @@ def test_201_single_message_with_valid_nhs_number():
 
 @pytest.mark.inttest
 @pytest.mark.parametrize('dob', VALID_DOB)
-def test_201_single_message_with_valid_dob(dob):
+def test_201_single_message_with_valid_dob(bearer_token_int, dob):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_dob.rst
     """
@@ -69,7 +70,7 @@ def test_201_single_message_with_valid_dob(dob):
     data["data"]["attributes"]["recipient"]["dateOfBirth"] = dob
 
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": Authentication.generate_authentication("int"),
+            "Authorization": bearer_token_int,
             "Accept": "application/json",
             "Content-Type": "application/json"
         }, json=data
@@ -78,7 +79,7 @@ def test_201_single_message_with_valid_dob(dob):
 
 
 @pytest.mark.inttest
-def test_single_message_request_without_dob():
+def test_single_message_request_without_dob(bearer_token_int):
     """
     .. include:: ../../partials/happy_path/test_201_messages_without_dob.rst
     """
@@ -86,7 +87,7 @@ def test_single_message_request_without_dob():
     data["data"]["attributes"]["recipient"].pop("dateOfBirth")
 
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "Accept": "application/json",
         "Content-Type": "application/json"
         }, json=data
@@ -95,14 +96,14 @@ def test_single_message_request_without_dob():
 
 
 @pytest.mark.inttest
-def test_201_message_request_idempotency():
+def test_201_message_request_idempotency(bearer_token_int):
     """
     .. include:: ../../partials/happy_path/test_201_messages_request_idempotency.rst
     """
     data = Generators.generate_valid_create_message_body("int")
 
     respOne = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "Accept": "application/json",
         "Content-Type": "application/json"
         }, json=data
@@ -111,7 +112,7 @@ def test_201_message_request_idempotency():
     time.sleep(5)
 
     respTwo = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "Accept": "application/json",
         "Content-Type": "application/json"
         }, json=data

--- a/tests/integration/messages/get_message/test_404.py
+++ b/tests/integration/messages/get_message/test_404.py
@@ -1,19 +1,20 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import INT_URL
 from lib.constants.messages_paths import MESSAGES_ENDPOINT, MESSAGE_ID_NOT_BELONGING_TO_CLIENT
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
-def test_message_id_not_belonging_to_client_id():
+def test_message_id_not_belonging_to_client_id(bearer_token_int):
     """
     .. include:: ../../partials/not_found/test_message_id_not_belonging_to_client_id.rst
     """
     resp = requests.get(
         f"{INT_URL}{MESSAGES_ENDPOINT}/{MESSAGE_ID_NOT_BELONGING_TO_CLIENT}",
-        headers={"Authorization": Authentication.generate_authentication("int")}
+        headers={"Authorization": bearer_token_int}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,
@@ -24,13 +25,13 @@ def test_message_id_not_belonging_to_client_id():
 
 
 @pytest.mark.inttest
-def test_message_id_that_does_not_exist():
+def test_message_id_that_does_not_exist(bearer_token_int):
     """
     .. include:: ../../partials/not_found/test_message_id_that_does_not_exist.rst
     """
     resp = requests.get(
         f"{INT_URL}{MESSAGES_ENDPOINT}/does_not_exist",
-        headers={"Authorization": Authentication.generate_authentication("int")}
+        headers={"Authorization": bearer_token_int}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/integration/messages/get_message/test_success.py
+++ b/tests/integration/messages/get_message/test_success.py
@@ -1,20 +1,21 @@
 import os
 import requests
 import pytest
-from lib import Assertions, Authentication
+from lib import Assertions
 from lib.constants.constants import INT_URL
 from lib.constants.messages_paths import MESSAGES_ENDPOINT, SUCCESSFUL_MESSAGE_IDS
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
 @pytest.mark.parametrize('message_ids', SUCCESSFUL_MESSAGE_IDS)
-def test_200_get_message(message_ids):
+def test_200_get_message(bearer_token_int, message_ids):
     """
     .. include:: ../../partials/happy_path/test_200_messages_message_id.rst
     """
     resp = requests.get(
         f"{INT_URL}{MESSAGES_ENDPOINT}/{message_ids}",
-        headers={"Authorization": Authentication.generate_authentication("int")}
+        headers={"Authorization": bearer_token_int}
         )
     Assertions.assert_200_response_message(resp, INT_URL)
     Assertions.assert_get_message_response_channels(resp, "email", "delivered")

--- a/tests/integration/nhsapp_accounts/test_400.py
+++ b/tests/integration/nhsapp_accounts/test_400.py
@@ -1,21 +1,22 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     VALID_MULTI_PAGE_NUMBERS, INVALID_ODS_CODES, CORRELATION_IDS, INVALID_PAGES, LIVE_ODS_CODES
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("page", VALID_MULTI_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_400_missing_ods_code(page, correlation_id):
+def test_400_missing_ods_code(bearer_token_int, page, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_missing_ods_code.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -33,13 +34,13 @@ def test_400_missing_ods_code(page, correlation_id):
 @pytest.mark.inttest
 @pytest.mark.parametrize("ods_code", INVALID_ODS_CODES)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_400_invalid_ods_code(ods_code, correlation_id):
+def test_400_invalid_ods_code(bearer_token_int, ods_code, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_ods_code.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -58,13 +59,13 @@ def test_400_invalid_ods_code(ods_code, correlation_id):
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", INVALID_PAGES)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_400_invalid_page(ods_code, page, correlation_id):
+def test_400_invalid_page(bearer_token_int, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_page.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/integration/nhsapp_accounts/test_404.py
+++ b/tests/integration/nhsapp_accounts/test_404.py
@@ -1,9 +1,10 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     LIVE_ODS_CODES, CORRELATION_IDS
+from lib.fixtures import *
 
 REPORT_NOT_FOUND_PAGE_NUMBERS = [1000, 2000, 3000]
 
@@ -12,13 +13,13 @@ REPORT_NOT_FOUND_PAGE_NUMBERS = [1000, 2000, 3000]
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", REPORT_NOT_FOUND_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_404_page_not_found(ods_code, page, correlation_id):
+def test_404_page_not_found(bearer_token_int, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_page_not_found.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/integration/nhsapp_accounts/test_success.py
+++ b/tests/integration/nhsapp_accounts/test_success.py
@@ -1,22 +1,23 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import INT_URL
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     LIVE_ODS_CODES, CORRELATION_IDS, VALID_SINGLE_PAGE_NUMBERS
+from lib.fixtures import *
 
 
 @pytest.mark.inttest
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", VALID_SINGLE_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_single_page(ods_code, page, correlation_id):
+def test_single_page(bearer_token_int, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_single_page.rst
     """
     resp = requests.get(f"{INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("int"),
+        "Authorization": bearer_token_int,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/integration/test_404_errors.py
+++ b/tests/integration/test_404_errors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import INT_URL, METHODS, CORRELATION_IDS
+from lib.fixtures import *
 
 POST_PATHS = ["/v1/ignore/i-dont-exist", "/api/fake-endpoint", "/im-a-teapot"]
 
@@ -10,12 +11,12 @@ POST_PATHS = ["/v1/ignore/i-dont-exist", "/api/fake-endpoint", "/im-a-teapot"]
 @pytest.mark.parametrize("request_path", POST_PATHS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
-def test_404_not_found(request_path, correlation_id, method):
+def test_404_not_found(bearer_token_int, request_path, correlation_id, method):
     """
     .. include:: ../../partials/not_found/test_404_not_found.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{request_path}", headers={
-        "Authorization": f"{Authentication.generate_authentication('int')}",
+        "Authorization": bearer_token_int,
         "X-Correlation-Id": correlation_id,
         "Accept": "*/*",
         "Content-Type": "application/json"

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,6 +1,6 @@
 from .assertions import Assertions
 from .permutations import Permutations
 from .generators import Generators
-from .authentication import Authentication
+from .authentication import AuthenticationCache
 from .error_handler import Error_Handler
 from .helper import Helper

--- a/tests/lib/app_keys.py
+++ b/tests/lib/app_keys.py
@@ -1,0 +1,39 @@
+
+def ensure_api_product_in_application(developer_app_keys_api, dev_email, app_name, key_id, api_product_name):
+    r = developer_app_keys_api.get_app_key(
+            dev_email,
+            app_name,
+            key_id
+            )
+    if {'apiproduct': api_product_name, 'status': 'approved'} not in r['apiProducts']:
+        print('adding proxy')
+        r2 = developer_app_keys_api.post_app_key(
+            email=dev_email,
+            app_name=app_name,
+            key=key_id,
+            body={'apiProducts': [api_product_name]}
+            )
+        return r2
+    else:
+        return r
+
+
+def ensure_api_product_not_in_application(
+        developer_app_keys_api,
+        dev_email,
+        app_name,
+        key_id,
+        api_product_name):
+    try:
+        return developer_app_keys_api.delete_product_app_key_association(
+                email=dev_email,
+                app_name=app_name,
+                app_key=key_id,
+                apiproduct_name=api_product_name
+                )
+    # we could do with the library giving a more specific error
+    #
+    # we want this for when the API product already doesn't exist and we have
+    # no need to remove anything (i.e. there are more than one test workers)
+    except Exception:
+        return None

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -1,0 +1,67 @@
+import pytest
+import os
+from .authentication import AuthenticationCache
+from .app_keys import ensure_api_product_in_application, ensure_api_product_not_in_application
+
+
+@pytest.fixture(scope='session')
+def proxy_name():
+    try:
+        return os.environ['API_PROXY']
+    except KeyError:
+        # fall back to PROXY_NAME
+        return os.environ['PROXY_NAME']
+
+
+# for now this is the same as PROXY_NAME
+# this is here to illustrate how these can be decoupled
+@pytest.fixture(scope='session')
+def api_product_name():
+    try:
+        return os.environ['API_PROXY']
+    except KeyError:
+        # fall back to PROXY_NAME
+        return os.environ['PROXY_NAME']
+
+
+# define one of these for each key we have set up and intend to use
+@pytest.fixture(scope='session')
+def api_product_in_comms_manager_local(developer_app_keys_api, api_product_name):
+    if api_product_name.startswith('communications-manager-pr-'):
+        yield ensure_api_product_in_application(
+                developer_app_keys_api,
+                'phillip.skinner2@nhs.net',
+                'Comms-manager-local',
+                os.environ['NON_PROD_API_KEY'],
+                api_product_name)
+        ensure_api_product_not_in_application(
+                developer_app_keys_api,
+                'phillip.skinner2@nhs.net',
+                'Comms-manager-local',
+                os.environ['NON_PROD_API_KEY'],
+                api_product_name)
+    else:
+        yield None
+
+
+# By setting the scope to session on the cache but leaving session scope OFF
+# the fixtures for each bearer token, we ensure the cache is checked and has a
+# chance to refresh before any test which might depend on a bearer token
+@pytest.fixture(scope='session')
+def authentication_cache():
+    return AuthenticationCache()
+
+
+@pytest.fixture
+def bearer_token_internal_dev(authentication_cache, api_product_in_comms_manager_local):
+    return authentication_cache.generate_authentication('internal-dev')
+
+
+@pytest.fixture
+def bearer_token_int(authentication_cache):
+    return authentication_cache.generate_authentication('int')
+
+
+@pytest.fixture
+def bearer_token_prod(authentication_cache):
+    return authentication_cache.generate_authentication('prod')

--- a/tests/production/content_types/test_406_errors.py
+++ b/tests/production/content_types/test_406_errors.py
@@ -1,19 +1,20 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import METHODS, PROD_URL, VALID_ENDPOINTS
+from lib.fixtures import *
 
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
 @pytest.mark.parametrize("method", METHODS)
-def test_406(method, endpoints):
+def test_406(bearer_token_prod, method, endpoints):
     """
     .. include:: ../../partials/content_types/test_406.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}/{endpoints}", headers={
         "Accept": "invalid",
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
     })
 
     Assertions.assert_error_with_optional_correlation_id(

--- a/tests/production/content_types/test_415_errors.py
+++ b/tests/production/content_types/test_415_errors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import CORRELATION_IDS, PROD_URL, VALID_ENDPOINTS
+from lib.fixtures import *
 
 METHODS = ["post", "put", "patch"]
 
@@ -9,12 +10,12 @@ METHODS = ["post", "put", "patch"]
 @pytest.mark.prodtest
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_415_invalid(method, endpoints):
+def test_415_invalid(bearer_token_prod, method, endpoints):
     """
     .. include:: ../../partials/content_types/test_415_invalid.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         "Accept": "application/json",
         "Content-Type": "invalid"
         })

--- a/tests/production/content_types/test_content_type_negotiation.py
+++ b/tests/production/content_types/test_content_type_negotiation.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Authentication, Error_Handler
+from lib import Error_Handler
 from lib.constants.constants import METHODS, PROD_URL, VALID_ENDPOINTS
+from lib.fixtures import *
 
 ACCEPT_HEADERS = [
     {
@@ -29,12 +30,12 @@ ACCEPT_HEADERS = [
 @pytest.mark.parametrize("accept_headers", ACCEPT_HEADERS)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_application_response_type(accept_headers, method, endpoints):
+def test_application_response_type(bearer_token_prod, accept_headers, method, endpoints):
     """
     .. include:: ../../partials/content_types/test_application_response_type.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         **accept_headers.get("headers")
     })
 

--- a/tests/production/headers/test_cors.py
+++ b/tests/production/headers/test_cors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Authentication
+from lib import Assertions
 from lib.constants.constants import PROD_URL, VALID_ENDPOINTS, ORIGIN
+from lib.fixtures import *
 
 METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
 TEST_METHODS = ["get", "post", "put", "delete"]
@@ -10,12 +11,12 @@ TEST_METHODS = ["get", "post", "put", "delete"]
 @pytest.mark.prodtest
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_cors_options(method, endpoints):
+def test_cors_options(bearer_token_prod, method, endpoints):
     """
     .. include :: ../../partials/headers/test_cors_options.rst
     """
     resp = requests.options(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method
@@ -26,12 +27,12 @@ def test_cors_options(method, endpoints):
 @pytest.mark.prodtest
 @pytest.mark.parametrize("method", TEST_METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_cors(method, endpoints):
+def test_cors(bearer_token_prod, method, endpoints):
     """
     .. include :: ../../partials/headers/test_cors.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         "Accept": "*/*",
         "Origin": ORIGIN
     })

--- a/tests/production/headers/test_x_amz_removal.py
+++ b/tests/production/headers/test_x_amz_removal.py
@@ -1,17 +1,18 @@
 import requests
 import pytest
 
-from lib import Assertions, Authentication
+from lib import Assertions
 from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS
+from lib.fixtures import *
 
 
 # Add prodtest once 4.9.0 is in prod
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("endpoints", VALID_ENDPOINTS)
-def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, endpoints, method):
+def test_request_with_x_amz_is_removed(bearer_token_prod, nhsd_apim_proxy_url, endpoints, method):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method

--- a/tests/production/headers/test_x_correlation_id.py
+++ b/tests/production/headers/test_x_correlation_id.py
@@ -1,8 +1,9 @@
 import requests
 import pytest
-from lib import Authentication, Error_Handler, Assertions
+from lib import Assertions, Error_Handler
 from lib.constants.constants import METHODS, PROD_URL
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 CORRELATION_IDS = [None, "a17669c8-219a-11ee-ba86-322b0407c489"]
 
@@ -11,6 +12,7 @@ CORRELATION_IDS = [None, "a17669c8-219a-11ee-ba86-322b0407c489"]
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
 @pytest.mark.parametrize("method", METHODS)
 def test_request_with_x_correlation_id(
+    bearer_token_prod,
     correlation_id,
     method,
 ):
@@ -18,7 +20,7 @@ def test_request_with_x_correlation_id(
     .. include:: ../../partials/headers/test_request_with_x_correlation_id.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         "x-correlation-id": correlation_id
     })
 

--- a/tests/production/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/production/message_batches/create_message_batches/test_field_validation.py
@@ -1,10 +1,11 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Permutations, Generators, Authentication
+from lib import Assertions, Permutations, Generators
 import lib.constants.constants as constants
 from lib.constants.message_batches_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
     INVALID_PROPERTIES_PATHS, DUPLICATE_PROPERTIES_PATHS, TOO_FEW_PROPERTIES_PATHS, MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 headers = {
     "Accept": "application/json",
@@ -16,7 +17,7 @@ INVALID_DOB = ["1990-10-1"]
 
 
 @pytest.mark.prodtest
-def test_invalid_body():
+def test_invalid_body(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_invalid_body.rst
     """
@@ -24,7 +25,7 @@ def test_invalid_body():
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         data="{}SF{}NOTVALID",
     )
@@ -39,7 +40,7 @@ def test_invalid_body():
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("property, pointer", MISSING_PROPERTIES_PATHS)
-def test_property_missing(property, pointer):
+def test_property_missing(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_message_batch_property_missing.rst
     """
@@ -47,7 +48,7 @@ def test_property_missing(property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_without_key(
             Generators.generate_valid_create_message_batch_body(),
@@ -65,7 +66,7 @@ def test_property_missing(property, pointer):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("property, pointer", NULL_PROPERTIES_PATHS)
-def test_data_null(property, pointer):
+def test_data_null(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_message_batch_null.rst
     """
@@ -73,7 +74,7 @@ def test_data_null(property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_null_key(
             Generators.generate_valid_create_message_batch_body(),
@@ -91,7 +92,7 @@ def test_data_null(property, pointer):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("property, pointer", INVALID_PROPERTIES_PATHS)
-def test_data_invalid(property, pointer):
+def test_data_invalid(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_message_batch_invalid.rst
     """
@@ -99,7 +100,7 @@ def test_data_invalid(property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body(),
@@ -118,7 +119,7 @@ def test_data_invalid(property, pointer):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("property, pointer", DUPLICATE_PROPERTIES_PATHS)
-def test_data_duplicate(property, pointer):
+def test_data_duplicate(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_data_duplicate.rst
     """
@@ -131,7 +132,7 @@ def test_data_duplicate(property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=data,
     )
@@ -146,7 +147,7 @@ def test_data_duplicate(property, pointer):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("property, pointer", TOO_FEW_PROPERTIES_PATHS)
-def test_data_too_few_items(property, pointer):
+def test_data_too_few_items(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_data_too_few_items.rst
     """
@@ -154,7 +155,7 @@ def test_data_too_few_items(property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body(),
@@ -173,13 +174,13 @@ def test_data_too_few_items(property, pointer):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("nhs_number", INVALID_NHS_NUMBER)
-def test_invalid_nhs_number(nhs_number):
+def test_invalid_nhs_number(bearer_token_prod, nhs_number):
     """
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -210,13 +211,13 @@ def test_invalid_nhs_number(nhs_number):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("dob", INVALID_DOB)
-def test_invalid_dob(dob):
+def test_invalid_dob(bearer_token_prod, dob):
     """
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -246,13 +247,13 @@ def test_invalid_dob(dob):
 
 
 @pytest.mark.prodtest
-def test_invalid_routing_plan():
+def test_invalid_routing_plan(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -282,13 +283,13 @@ def test_invalid_routing_plan():
 
 
 @pytest.mark.prodtest
-def test_invalid_message_batch_reference():
+def test_invalid_message_batch_reference(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_invalid_message_batch_reference.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -318,13 +319,13 @@ def test_invalid_message_batch_reference():
 
 
 @pytest.mark.prodtest
-def test_invalid_message_reference():
+def test_invalid_message_reference(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -355,13 +356,13 @@ def test_invalid_message_reference():
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("invalid_value", INVALID_MESSAGE_VALUES)
-def test_blank_value_under_messages(invalid_value):
+def test_blank_value_under_messages(bearer_token_prod, invalid_value):
     """
     .. include:: ../../partials/validation/test_blank_value_under_messages.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -384,13 +385,13 @@ def test_blank_value_under_messages(invalid_value):
 
 
 @pytest.mark.prodtest
-def test_null_value_under_messages():
+def test_null_value_under_messages(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_null_value_under_messages.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -414,13 +415,13 @@ def test_null_value_under_messages():
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("personalisation", constants.INVALID_PERSONALISATION_VALUES)
-def test_invalid_personalisation(personalisation):
+def test_invalid_personalisation(bearer_token_prod, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -451,13 +452,13 @@ def test_invalid_personalisation(personalisation):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("personalisation", constants.NULL_VALUES)
-def test_null_personalisation(personalisation):
+def test_null_personalisation(bearer_token_prod, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json={
         "data": {
             "type": "MessageBatch",

--- a/tests/production/message_batches/create_message_batches/test_invalid_routing_config.py
+++ b/tests/production/message_batches/create_message_batches/test_invalid_routing_config.py
@@ -1,20 +1,21 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import PROD_URL, INVALID_ROUTING_PLAN_PROD
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 
 @pytest.mark.prodtest
-def test_no_such_routing_plan():
+def test_no_such_routing_plan(bearer_token_prod):
     """
     ..py:function:: test_no_such_routing_plan
 
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -44,12 +45,12 @@ def test_no_such_routing_plan():
 
 
 @pytest.mark.prodtest
-def test_routing_plan_not_belonging_to_client_id():
+def test_routing_plan_not_belonging_to_client_id(bearer_token_prod):
     """
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
     }, json={
         "data": {
             "type": "MessageBatch",

--- a/tests/production/message_batches/create_message_batches/test_performance.py
+++ b/tests/production/message_batches/create_message_batches/test_performance.py
@@ -1,15 +1,16 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import PROD_URL, NUM_MAX_ERRORS
 from lib.constants.message_batches_paths import MESSAGE_BATCHES_ENDPOINT
+from lib.fixtures import *
 
 NUM_MESSAGES = 50000
 
 
 @pytest.mark.prodtest
-def test_create_messages_large_invalid_payload():
+def test_create_messages_large_invalid_payload(bearer_token_prod):
     """
     .. include:: ../../partials/performance/test_create_messages_large_valid_payload.rst
     """
@@ -29,7 +30,7 @@ def test_create_messages_large_invalid_payload():
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)
@@ -37,7 +38,7 @@ def test_create_messages_large_invalid_payload():
 
 
 @pytest.mark.prodtest
-def test_create_messages_large_not_unique_payload():
+def test_create_messages_large_not_unique_payload(bearer_token_prod):
     """
     .. include:: ../../partials/performance/test_create_messages_large_not_unique_payload.rst
     """
@@ -58,7 +59,7 @@ def test_create_messages_large_not_unique_payload():
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "Authorization": f"{Authentication.generate_authentication('prod')}"
+        "Authorization": bearer_token_prod
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)

--- a/tests/production/messages/create_messages/test_field_validation.py
+++ b/tests/production/messages/create_messages/test_field_validation.py
@@ -1,9 +1,10 @@
 import requests
 import pytest
-from lib import Assertions, Permutations, Generators, Authentication
+from lib import Assertions, Permutations, Generators
 import lib.constants.constants as constants
 from lib.constants.messages_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
     INVALID_PROPERTIES_PATHS, MESSAGES_ENDPOINT
+from lib.fixtures import *
 
 headers = {
     "Accept": "application/json",
@@ -12,7 +13,7 @@ headers = {
 
 
 @pytest.mark.prodtest
-def test_invalid_body():
+def test_invalid_body(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_messages_invalid.rst
     """
@@ -20,7 +21,7 @@ def test_invalid_body():
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         data="{}SF{}NOTVALID",
     )
@@ -38,7 +39,7 @@ def test_invalid_body():
     "property, pointer",
     MISSING_PROPERTIES_PATHS
 )
-def test_property_missing(property, pointer):
+def test_property_missing(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_messages_property_missing.rst
     """
@@ -46,7 +47,7 @@ def test_property_missing(property, pointer):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_without_key(
             Generators.generate_valid_create_message_body("prod"),
@@ -67,7 +68,7 @@ def test_property_missing(property, pointer):
     "property, pointer",
     NULL_PROPERTIES_PATHS
 )
-def test_data_null(property, pointer):
+def test_data_null(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_messages_null.rst
     """
@@ -75,7 +76,7 @@ def test_data_null(property, pointer):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_null_key(
             Generators.generate_valid_create_message_body("prod"),
@@ -96,7 +97,7 @@ def test_data_null(property, pointer):
     "property, pointer",
     INVALID_PROPERTIES_PATHS
 )
-def test_data_invalid(property, pointer):
+def test_data_invalid(bearer_token_prod, property, pointer):
     """
     .. include:: ../../partials/validation/test_messages_invalid.rst
     """
@@ -104,7 +105,7 @@ def test_data_invalid(property, pointer):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -123,7 +124,7 @@ def test_data_invalid(property, pointer):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("nhs_number", constants.INVALID_NHS_NUMBER)
-def test_invalid_nhs_number(nhs_number):
+def test_invalid_nhs_number(bearer_token_prod, nhs_number):
     """
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
@@ -131,7 +132,7 @@ def test_invalid_nhs_number(nhs_number):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -150,7 +151,7 @@ def test_invalid_nhs_number(nhs_number):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("dob", constants.INVALID_DOB)
-def test_invalid_dob(dob):
+def test_invalid_dob(bearer_token_prod, dob):
     """
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
@@ -158,7 +159,7 @@ def test_invalid_dob(dob):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -176,7 +177,7 @@ def test_invalid_dob(dob):
 
 
 @pytest.mark.prodtest
-def test_invalid_routing_plan():
+def test_invalid_routing_plan(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
@@ -184,7 +185,7 @@ def test_invalid_routing_plan():
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -202,7 +203,7 @@ def test_invalid_routing_plan():
 
 
 @pytest.mark.prodtest
-def test_invalid_message_reference():
+def test_invalid_message_reference(bearer_token_prod):
     """
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
@@ -210,7 +211,7 @@ def test_invalid_message_reference():
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -229,7 +230,7 @@ def test_invalid_message_reference():
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("personalisation", constants.INVALID_PERSONALISATION_VALUES)
-def test_invalid_personalisation(personalisation):
+def test_invalid_personalisation(bearer_token_prod, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
@@ -237,7 +238,7 @@ def test_invalid_personalisation(personalisation):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -256,7 +257,7 @@ def test_invalid_personalisation(personalisation):
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("personalisation", constants.NULL_VALUES)
-def test_null_personalisation(personalisation):
+def test_null_personalisation(bearer_token_prod, personalisation):
     """
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
@@ -264,7 +265,7 @@ def test_null_personalisation(personalisation):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),

--- a/tests/production/messages/create_messages/test_invalid_routing_plan.py
+++ b/tests/production/messages/create_messages/test_invalid_routing_plan.py
@@ -1,10 +1,11 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Permutations, Generators, Authentication
+from lib import Assertions, Permutations, Generators
 import lib.constants.constants as constants
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
 from lib.constants.constants import INVALID_ROUTING_PLAN_PROD
+from lib.fixtures import *
 
 
 headers = {
@@ -14,7 +15,7 @@ headers = {
 
 
 @pytest.mark.prodtest
-def test_no_such_routing_plan():
+def test_no_such_routing_plan(bearer_token_prod):
     """
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
@@ -22,7 +23,7 @@ def test_no_such_routing_plan():
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -40,7 +41,7 @@ def test_no_such_routing_plan():
 
 
 @pytest.mark.prodtest
-def test_routing_plan_not_belonging_to_client_id():
+def test_routing_plan_not_belonging_to_client_id(bearer_token_prod):
     """
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
@@ -48,7 +49,7 @@ def test_routing_plan_not_belonging_to_client_id():
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": f"{Authentication.generate_authentication('prod')}"
+            "Authorization": bearer_token_prod
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),

--- a/tests/production/messages/get_message/test_404.py
+++ b/tests/production/messages/get_message/test_404.py
@@ -1,19 +1,20 @@
 import requests
 import pytest
 import uuid
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import PROD_URL
 from lib.constants.messages_paths import MESSAGES_ENDPOINT, MESSAGE_ID_NOT_BELONGING_TO_CLIENT
+from lib.fixtures import *
 
 
 @pytest.mark.prodtest
-def test_message_id_not_belonging_to_client_id():
+def test_message_id_not_belonging_to_client_id(bearer_token_prod):
     """
     .. include:: ../../partials/not_found/test_message_id_not_belonging_to_client_id.rst
     """
     resp = requests.get(
         f"{PROD_URL}{MESSAGES_ENDPOINT}/{MESSAGE_ID_NOT_BELONGING_TO_CLIENT}",
-        headers={"Authorization": Authentication.generate_authentication("prod")}
+        headers={"Authorization": bearer_token_prod}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,
@@ -24,13 +25,13 @@ def test_message_id_not_belonging_to_client_id():
 
 
 @pytest.mark.prodtest
-def test_message_id_that_does_not_exist():
+def test_message_id_that_does_not_exist(bearer_token_prod):
     """
     .. include:: ../../partials/not_found/test_message_id_that_does_not_exist.rst
     """
     resp = requests.get(
         f"{PROD_URL}{MESSAGES_ENDPOINT}/does_not_exist",
-        headers={"Authorization": Authentication.generate_authentication("prod")}
+        headers={"Authorization": bearer_token_prod}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/production/messages/get_message/test_success.py
+++ b/tests/production/messages/get_message/test_success.py
@@ -1,21 +1,22 @@
 import os
 import requests
 import pytest
-from lib import Assertions, Authentication
+from lib import Assertions
 from lib.constants.constants import PROD_URL
 from lib.constants.messages_paths import MESSAGES_ENDPOINT, SUCCESSFUL_MESSAGE_IDS
+from lib.fixtures import *
 
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize('message_ids', SUCCESSFUL_MESSAGE_IDS)
-def test_200_get_message(message_ids):
+def test_200_get_message(bearer_token_prod, message_ids):
     """
     .. include:: ../../partials/happy_path/test_200_messages_message_id.rst
     .. include:: ../../partials/valid_message_ids.rst
     """
     resp = requests.get(
         f"{PROD_URL}{MESSAGES_ENDPOINT}/{message_ids}",
-        headers={"Authorization": Authentication.generate_authentication("prod")}
+        headers={"Authorization": bearer_token_prod}
         )
     Assertions.assert_200_response_message(resp, PROD_URL)
     Assertions.assert_get_message_response_channels(resp, "email", "delivered")

--- a/tests/production/nhsapp_accounts/test_400.py
+++ b/tests/production/nhsapp_accounts/test_400.py
@@ -1,21 +1,22 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     VALID_MULTI_PAGE_NUMBERS, INVALID_ODS_CODES, CORRELATION_IDS, INVALID_PAGES, LIVE_ODS_CODES
+from lib.fixtures import *
 
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("page", VALID_MULTI_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_400_missing_ods_code(page, correlation_id):
+def test_400_missing_ods_code(bearer_token_prod, page, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_missing_ods_code.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("prod"),
+        "Authorization": bearer_token_prod,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -33,13 +34,13 @@ def test_400_missing_ods_code(page, correlation_id):
 @pytest.mark.prodtest
 @pytest.mark.parametrize("ods_code", INVALID_ODS_CODES)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_400_invalid_ods_code(ods_code, correlation_id):
+def test_400_invalid_ods_code(bearer_token_prod, ods_code, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_ods_code.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("prod"),
+        "Authorization": bearer_token_prod,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -58,13 +59,13 @@ def test_400_invalid_ods_code(ods_code, correlation_id):
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", INVALID_PAGES)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_400_invalid_page(ods_code, page, correlation_id):
+def test_400_invalid_page(bearer_token_prod, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_page.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("prod"),
+        "Authorization": bearer_token_prod,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/production/nhsapp_accounts/test_404.py
+++ b/tests/production/nhsapp_accounts/test_404.py
@@ -1,9 +1,10 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 import lib.constants.constants as constants
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     LIVE_ODS_CODES, CORRELATION_IDS
+from lib.fixtures import *
 
 REPORT_NOT_FOUND_PAGE_NUMBERS = [1000, 2000, 3000]
 
@@ -12,13 +13,13 @@ REPORT_NOT_FOUND_PAGE_NUMBERS = [1000, 2000, 3000]
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", REPORT_NOT_FOUND_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_404_page_not_found(ods_code, page, correlation_id):
+def test_404_page_not_found(bearer_token_prod, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_page_not_found.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("prod"),
+        "Authorization": bearer_token_prod,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/production/nhsapp_accounts/test_success.py
+++ b/tests/production/nhsapp_accounts/test_success.py
@@ -1,23 +1,24 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import PROD_URL
 from lib.constants.nhsapp_accounts_paths import NHSAPP_ACCOUNTS_ENDPOINT, ODS_CODE_PARAM_NAME, PAGE_PARAM_NAME, \
     LIVE_ODS_CODES, CORRELATION_IDS, VALID_MULTI_PAGE_NUMBERS, \
     MULTI_LAST_PAGE, VALID_SINGLE_PAGE_NUMBERS
+from lib.fixtures import *
 
 
 @pytest.mark.prodtest
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", VALID_SINGLE_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_single_page(ods_code, page, correlation_id):
+def test_single_page(bearer_token_prod, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_single_page.rst
     """
     resp = requests.get(f"{PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("prod"),
+        "Authorization": bearer_token_prod,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -32,13 +33,13 @@ def test_single_page(ods_code, page, correlation_id):
 @pytest.mark.parametrize("ods_code", LIVE_ODS_CODES)
 @pytest.mark.parametrize("page", VALID_MULTI_PAGE_NUMBERS)
 @pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
-def test_multi_pages(ods_code, page, correlation_id):
+def test_multi_pages(bearer_token_prod, ods_code, page, correlation_id):
 
     """
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_multi_pages.rst
     """
     resp = requests.get(f"{PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": Authentication.generate_authentication("prod"),
+        "Authorization": bearer_token_prod,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/production/test_404_errors.py
+++ b/tests/production/test_404_errors.py
@@ -1,7 +1,8 @@
 import requests
 import pytest
-from lib import Assertions, Generators, Authentication
+from lib import Assertions, Generators
 from lib.constants.constants import *
+from lib.fixtures import *
 
 POST_PATHS = ["/v1/ignore/i-dont-exist"]
 METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
@@ -10,12 +11,12 @@ METHODS = ["get", "post", "put", "patch", "delete", "head", "options"]
 @pytest.mark.prodtest
 @pytest.mark.parametrize("request_path", POST_PATHS)
 @pytest.mark.parametrize("method", METHODS)
-def test_404_not_found(request_path, method):
+def test_404_not_found(bearer_token_prod, request_path, method):
     """
     .. include:: ../../partials/not_found/test_404_not_found.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{request_path}", headers={
-        "Authorization": f"{Authentication.generate_authentication('prod')}",
+        "Authorization": bearer_token_prod,
         "Accept": "*/*",
         "Content-Type": "application/json"
     })


### PR DESCRIPTION
## Summary

This MR adds back the auth fixtures change which we backed out of, this time including a fix to the pipeline to make sure it nightly tests pass

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
