### PR TITLE
CCM-5702 Obfuscate bearer tokens in logs

### DIFF
--- a/tests/development/content_types/test_406_errors.py
+++ b/tests/development/content_types/test_406_errors.py
@@ -29,7 +29,7 @@ def test_406(
     .. include:: ../../partials/content_types/test_406.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         accept_header_name: accept_header_value,
         "X-Correlation-Id": correlation_id
     })

--- a/tests/development/content_types/test_415_errors.py
+++ b/tests/development/content_types/test_415_errors.py
@@ -29,7 +29,7 @@ def test_415_invalid(
     .. include:: ../../partials/content_types/test_415_invalid.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "Accept": "application/json",
         content_type_name: content_type_value,
         "X-Correlation-Id": correlation_id

--- a/tests/development/content_types/test_content_type_negotiation.py
+++ b/tests/development/content_types/test_content_type_negotiation.py
@@ -36,7 +36,7 @@ def test_application_response_type(nhsd_apim_proxy_url, bearer_token_internal_de
     .. include:: ../../partials/content_types/test_application_response_type.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **accept_headers.get("headers")
     })
 

--- a/tests/development/content_types/test_missing_accept_header.py
+++ b/tests/development/content_types/test_missing_accept_header.py
@@ -27,7 +27,7 @@ def test_missing_accept_header(
         headers={
             "Content-Type": content_type,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
         },
         json=data
     )

--- a/tests/development/headers/test_cors.py
+++ b/tests/development/headers/test_cors.py
@@ -20,7 +20,7 @@ def test_cors_options(nhsd_apim_proxy_url, bearer_token_internal_dev, method, en
     .. include :: ../../partials/headers/test_cors_options.rst
     """
     resp = requests.options(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method
@@ -38,7 +38,7 @@ def test_cors(nhsd_apim_proxy_url, bearer_token_internal_dev, method, endpoints)
     .. include :: ../../partials/headers/test_cors.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "Accept": "*/*",
         "Origin": ORIGIN
     })

--- a/tests/development/headers/test_x_amz_removal.py
+++ b/tests/development/headers/test_x_amz_removal.py
@@ -12,7 +12,7 @@ from lib.constants.constants import VALID_ENDPOINTS, ORIGIN, METHODS
 def test_request_with_x_amz_is_removed(nhsd_apim_proxy_url, bearer_token_internal_dev, endpoints, method,):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method

--- a/tests/development/headers/test_x_correlation_id.py
+++ b/tests/development/headers/test_x_correlation_id.py
@@ -26,7 +26,7 @@ def test_request_with_x_correlation_id(
     .. include:: ../../partials/headers/test_request_with_x_correlation_id.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{endpoints}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "x-correlation-id": correlation_id
     })
 

--- a/tests/development/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/development/message_batches/create_message_batches/test_field_validation.py
@@ -24,7 +24,7 @@ def test_invalid_body(nhsd_apim_proxy_url, bearer_token_internal_dev, correlatio
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -52,7 +52,7 @@ def test_property_missing(nhsd_apim_proxy_url, bearer_token_internal_dev, proper
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -83,7 +83,7 @@ def test_data_null(nhsd_apim_proxy_url, bearer_token_internal_dev, property, poi
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -114,7 +114,7 @@ def test_data_invalid(nhsd_apim_proxy_url, bearer_token_internal_dev, property, 
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -151,7 +151,7 @@ def test_data_duplicate(nhsd_apim_proxy_url, bearer_token_internal_dev, property
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -179,7 +179,7 @@ def test_data_too_few_items(nhsd_apim_proxy_url, bearer_token_internal_dev, prop
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -206,7 +206,7 @@ def test_invalid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal_dev, nhs_
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -244,7 +244,7 @@ def test_invalid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, dob, correl
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -282,7 +282,7 @@ def test_invalid_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -320,7 +320,7 @@ def test_invalid_message_batch_reference(nhsd_apim_proxy_url, bearer_token_inter
     .. include:: ../../partials/validation/test_invalid_message_batch_reference.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -358,7 +358,7 @@ def test_invalid_message_reference(nhsd_apim_proxy_url, bearer_token_internal_de
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -397,7 +397,7 @@ def test_blank_value_under_messages(nhsd_apim_proxy_url, bearer_token_internal_d
     .. include:: ../../partials/validation/test_blank_value_under_messages.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -428,7 +428,7 @@ def test_null_value_under_messages(nhsd_apim_proxy_url, bearer_token_internal_de
     .. include:: ../../partials/validation/test_null_value_under_messages.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -460,7 +460,7 @@ def test_invalid_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev,
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -499,7 +499,7 @@ def test_null_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={

--- a/tests/development/message_batches/create_message_batches/test_invalid_routing_plan.py
+++ b/tests/development/message_batches/create_message_batches/test_invalid_routing_plan.py
@@ -17,7 +17,7 @@ def test_no_such_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {
@@ -54,7 +54,7 @@ def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, bearer_tok
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {
@@ -97,7 +97,7 @@ def test_routing_plan_missing_templates(
     .. include:: ../../partials/invalid_routing_plans/test_500_missing_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {

--- a/tests/development/message_batches/create_message_batches/test_performance.py
+++ b/tests/development/message_batches/create_message_batches/test_performance.py
@@ -29,7 +29,7 @@ def test_create_messages_large_invalid_payload(nhsd_apim_proxy_url, bearer_token
         })
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE
     }, json=data
@@ -58,7 +58,7 @@ def test_create_messages_large_not_unique_payload(nhsd_apim_proxy_url, bearer_to
         })
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE
     }, json=data

--- a/tests/development/message_batches/create_message_batches/test_success.py
+++ b/tests/development/message_batches/create_message_batches/test_success.py
@@ -19,7 +19,7 @@ def test_201_message_batch_valid_accept_headers(
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -44,7 +44,7 @@ def test_201_message_batch_valid_content_type_headers(
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": content_type,
         },
@@ -73,7 +73,7 @@ def test_201_message_batch_valid_nhs_number(
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -98,7 +98,7 @@ def test_201_message_batch_valid_dob(nhsd_apim_proxy_url, bearer_token_internal_
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -122,7 +122,7 @@ def test_request_without_dob(nhsd_apim_proxy_url, bearer_token_internal_dev):
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -148,7 +148,7 @@ def test_201_message_batches_request_idempotency(
     respOne = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },
@@ -160,7 +160,7 @@ def test_201_message_batches_request_idempotency(
     respTwo = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE,
         },

--- a/tests/development/messages/create_messages/test_field_validation.py
+++ b/tests/development/messages/create_messages/test_field_validation.py
@@ -24,7 +24,7 @@ def test_invalid_body(nhsd_apim_proxy_url, bearer_token_internal_dev, correlatio
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -52,7 +52,7 @@ def test_property_missing(nhsd_apim_proxy_url, bearer_token_internal_dev, proper
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -83,7 +83,7 @@ def test_data_null(nhsd_apim_proxy_url, bearer_token_internal_dev, property, poi
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -114,7 +114,7 @@ def test_data_invalid(nhsd_apim_proxy_url, bearer_token_internal_dev, property, 
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -141,7 +141,7 @@ def test_invalid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal_dev, nhs_
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -176,7 +176,7 @@ def test_invalid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, dob, correl
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -210,7 +210,7 @@ def test_invalid_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -244,7 +244,7 @@ def test_invalid_message_reference(nhsd_apim_proxy_url, bearer_token_internal_de
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -279,7 +279,7 @@ def test_invalid_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev,
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -313,7 +313,7 @@ def test_null_personalisation(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={

--- a/tests/development/messages/create_messages/test_invalid_routing_plan.py
+++ b/tests/development/messages/create_messages/test_invalid_routing_plan.py
@@ -17,7 +17,7 @@ def test_no_such_routing_plan(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "X-Correlation-Id": correlation_id
         },
         json={
@@ -51,7 +51,7 @@ def test_routing_plan_not_belonging_to_client_id(nhsd_apim_proxy_url, bearer_tok
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "X-Correlation-Id": correlation_id
         },
         json={
@@ -91,7 +91,7 @@ def test_routing_plan_missing_templates(
     .. include:: ../../partials/invalid_routing_plans/test_500_missing_routing_plan.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {

--- a/tests/development/messages/create_messages/test_success.py
+++ b/tests/development/messages/create_messages/test_success.py
@@ -15,7 +15,7 @@ def test_201_message_valid_accept_headers(nhsd_apim_proxy_url, bearer_token_inte
     """
     data = Generators.generate_valid_create_message_body("dev")
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -32,7 +32,7 @@ def test_201_message_valid_content_type_headers(nhsd_apim_proxy_url, bearer_toke
     """
     data = Generators.generate_valid_create_message_body("dev")
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": content_type
         }, json=data
@@ -50,7 +50,7 @@ def test_201_message_valid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal
     data["data"]["attributes"]["recipient"]["nhsNumber"] = constants.VALID_NHS_NUMBER
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -69,7 +69,7 @@ def test_201_message_valid_dob(nhsd_apim_proxy_url, bearer_token_internal_dev, d
     data["data"]["attributes"]["recipient"]["dateOfBirth"] = dob
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -87,7 +87,7 @@ def test_request_without_dob(nhsd_apim_proxy_url, bearer_token_internal_dev):
     data["data"]["attributes"]["recipient"].pop("dateOfBirth")
 
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -104,7 +104,7 @@ def test_201_message_request_idempotency(nhsd_apim_proxy_url, bearer_token_inter
     data = Generators.generate_valid_create_message_body("dev")
 
     respOne = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data
@@ -113,7 +113,7 @@ def test_201_message_request_idempotency(nhsd_apim_proxy_url, bearer_token_inter
     time.sleep(5)
 
     respTwo = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": constants.DEFAULT_CONTENT_TYPE,
             "Content-Type": constants.DEFAULT_CONTENT_TYPE
         }, json=data

--- a/tests/development/messages/get_message/test_404.py
+++ b/tests/development/messages/get_message/test_404.py
@@ -12,7 +12,7 @@ def test_message_id_not_belonging_to_client_id(nhsd_apim_proxy_url, bearer_token
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/successful_email_other_owner",
-        headers={"Authorization": bearer_token_internal_dev}
+        headers={"Authorization": bearer_token_internal_dev.value}
     )
     Assertions.assert_error_with_optional_correlation_id(
         resp,
@@ -29,7 +29,7 @@ def test_message_id_that_does_not_exist(nhsd_apim_proxy_url, bearer_token_intern
     """
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/does_not_exist",
-        headers={"Authorization": bearer_token_internal_dev}
+        headers={"Authorization": bearer_token_internal_dev.value}
     )
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/development/messages/get_message/test_success.py
+++ b/tests/development/messages/get_message/test_success.py
@@ -16,7 +16,7 @@ def test_200_get_message(nhsd_apim_proxy_url, bearer_token_internal_dev, accept_
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/{message_ids}",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -33,7 +33,7 @@ def test_200_get_message_pending_enrichment(nhsd_apim_proxy_url, bearer_token_in
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/pending_enrichment_request_item_id",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -51,7 +51,7 @@ def test_200_get_message_sending(nhsd_apim_proxy_url, bearer_token_internal_dev,
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/sending_nhsapp_request_item_id",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -69,7 +69,7 @@ def test_200_get_message_successful(nhsd_apim_proxy_url, bearer_token_internal_d
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/successful_letter_request_item_id",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -87,7 +87,7 @@ def test_200_get_message_failed(nhsd_apim_proxy_url, bearer_token_internal_dev, 
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/exit_code_request_item_id",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -105,7 +105,7 @@ def test_200_get_message_cascade(nhsd_apim_proxy_url, bearer_token_internal_dev,
     resp = requests.get(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}/cascade_sending_all_status_request_item_id",
         headers={
-            "Authorization": bearer_token_internal_dev,
+            "Authorization": bearer_token_internal_dev.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },

--- a/tests/development/nhsapp_accounts/test_400.py
+++ b/tests/development/nhsapp_accounts/test_400.py
@@ -16,7 +16,7 @@ def test_400_missing_ods_code(nhsd_apim_proxy_url, bearer_token_internal_dev, pa
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_missing_ods_code.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -40,7 +40,7 @@ def test_400_invalid_ods_code(nhsd_apim_proxy_url, bearer_token_internal_dev, od
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_ods_code.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -65,7 +65,7 @@ def test_400_invalid_page(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_co
     .. include:: ../../partials/invalid_page/test_400_nhsapp_accounts_invalid_page.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_404.py
+++ b/tests/development/nhsapp_accounts/test_404.py
@@ -20,7 +20,7 @@ def test_404_page_not_found(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_page_not_found.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -44,7 +44,7 @@ def test_404_report_not_found(nhsd_apim_proxy_url, bearer_token_internal_dev, co
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_report_not_found.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_429.py
+++ b/tests/development/nhsapp_accounts/test_429.py
@@ -17,7 +17,7 @@ def test_429_too_many_requests(nhsd_apim_proxy_url, bearer_token_internal_dev, c
     .. include:: ../../partials/too_many_requests/test_429_nhs_app_accounts_too_many_requests.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_502.py
+++ b/tests/development/nhsapp_accounts/test_502.py
@@ -17,7 +17,7 @@ def test_502_bad_gateway(nhsd_apim_proxy_url, bearer_token_internal_dev, correla
     .. include:: ../../partials/bad_gatway/test_502_bad_gateway.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/nhsapp_accounts/test_success.py
+++ b/tests/development/nhsapp_accounts/test_success.py
@@ -17,7 +17,7 @@ def test_single_page(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, p
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_single_page.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -39,7 +39,7 @@ def test_multi_pages(nhsd_apim_proxy_url, bearer_token_internal_dev, ods_code, p
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_multi_pages.rst
     """
     resp = requests.get(f"{nhsd_apim_proxy_url}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/development/test_404_errors.py
+++ b/tests/development/test_404_errors.py
@@ -17,7 +17,7 @@ def test_404_not_found(nhsd_apim_proxy_url, bearer_token_internal_dev, request_p
     .. include:: ../../partials/not_found/test_404_not_found.rst
     """
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}{request_path}", headers={
-        "Authorization": bearer_token_internal_dev,
+        "Authorization": bearer_token_internal_dev.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "*/*",
         "Content-Type": "application/json"

--- a/tests/end_to_end/test_email.py
+++ b/tests/end_to_end/test_email.py
@@ -13,7 +13,7 @@ def test_email_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_interna
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("email", "internal-dev")
     )
 
@@ -21,7 +21,7 @@ def test_email_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_interna
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id
     )
 
@@ -39,7 +39,7 @@ def test_email_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("email", "internal-qa")
     )
 
@@ -47,7 +47,7 @@ def test_email_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id
     )
 

--- a/tests/end_to_end/test_letter.py
+++ b/tests/end_to_end/test_letter.py
@@ -13,7 +13,7 @@ def test_letter_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_intern
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("letter", "internal-dev"),
     )
 
@@ -21,7 +21,7 @@ def test_letter_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_intern
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id,
         end_state="sending",
         poll_time=595,
@@ -43,7 +43,7 @@ def test_letter_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("letter", "internal-qa"),
     )
 
@@ -51,7 +51,7 @@ def test_letter_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id,
         end_state="sending",
         poll_time=595,

--- a/tests/end_to_end/test_nhsapp.py
+++ b/tests/end_to_end/test_nhsapp.py
@@ -12,7 +12,7 @@ def test_nhsapp_end_to_end(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("nhsapp", "internal-dev")
     )
 
@@ -20,14 +20,14 @@ def test_nhsapp_end_to_end(nhsd_apim_proxy_url, bearer_token_internal_dev):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id
     )
 
     Assertions.assert_get_message_status(
         Helper.get_message(
             nhsd_apim_proxy_url,
-            {"Authorization": bearer_token_internal_dev},
+            {"Authorization": bearer_token_internal_dev.value},
             message_id
         ),
         "delivered"
@@ -44,7 +44,7 @@ def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
 
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("nhsapp", "internal-qa", personalisation)
     )
 
@@ -52,7 +52,7 @@ def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id,
         end_state="sending"
     )
@@ -60,7 +60,7 @@ def test_nhsapp_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     Assertions.assert_get_message_status(
         Helper.get_message(
             nhsd_apim_proxy_url,
-            {"Authorization": bearer_token_internal_dev},
+            {"Authorization": bearer_token_internal_dev.value},
             message_id
         ),
         "sending"

--- a/tests/end_to_end/test_sms.py
+++ b/tests/end_to_end/test_sms.py
@@ -13,7 +13,7 @@ def test_sms_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_internal_
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("sms", "internal-dev")
     )
 
@@ -21,7 +21,7 @@ def test_sms_end_to_end_internal_dev(nhsd_apim_proxy_url, bearer_token_internal_
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id
     )
 
@@ -39,7 +39,7 @@ def test_sms_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     resp = Helper.send_single_message(
         nhsd_apim_proxy_url,
-        {"Authorization": bearer_token_internal_dev},
+        {"Authorization": bearer_token_internal_dev.value},
         Generators.generate_send_message_body("sms", "internal-qa")
     )
 
@@ -47,7 +47,7 @@ def test_sms_end_to_end_uat(nhsd_apim_proxy_url, bearer_token_internal_dev):
 
     Helper.poll_get_message(
         url=nhsd_apim_proxy_url,
-        auth={"Authorization": bearer_token_internal_dev},
+        auth={"Authorization": bearer_token_internal_dev.value},
         message_id=message_id
     )
 

--- a/tests/integration/content_types/test_406_errors.py
+++ b/tests/integration/content_types/test_406_errors.py
@@ -28,7 +28,7 @@ def test_406(
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
         accept_header_name: accept_header_value,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
     })
 
     Assertions.assert_error_with_optional_correlation_id(

--- a/tests/integration/content_types/test_415_errors.py
+++ b/tests/integration/content_types/test_415_errors.py
@@ -27,7 +27,7 @@ def test_415_invalid(
     .. include:: ../../partials/content_types/test_415_invalid.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "application/json",
         content_type_name: content_type_value,
         "X-Correlation-Id": correlation_id

--- a/tests/integration/content_types/test_content_type_negotiation.py
+++ b/tests/integration/content_types/test_content_type_negotiation.py
@@ -36,7 +36,7 @@ def test_application_response_type(bearer_token_int, accept_headers, method, end
     .. include:: ../../partials/content_types/test_application_response_type.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **accept_headers.get("headers")
     })
 

--- a/tests/integration/headers/test_cors.py
+++ b/tests/integration/headers/test_cors.py
@@ -16,7 +16,7 @@ def test_cors_options(bearer_token_int, method, endpoints):
     .. include :: ../../partials/headers/test_cors_options.rst
     """
     resp = requests.options(f"{INT_URL}{endpoints}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method
@@ -32,7 +32,7 @@ def test_cors(bearer_token_int, method, endpoints):
     .. include :: ../../partials/headers/test_cors.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "*/*",
         "Origin": ORIGIN
     })

--- a/tests/integration/headers/test_x_amz_removal.py
+++ b/tests/integration/headers/test_x_amz_removal.py
@@ -12,7 +12,7 @@ from lib.fixtures import *
 def test_request_with_x_amz_is_removed(bearer_token_int, endpoints, method):
 
     resp = getattr(requests, method)(f"{INT_URL}/{endpoints}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method

--- a/tests/integration/headers/test_x_correlation_id.py
+++ b/tests/integration/headers/test_x_correlation_id.py
@@ -16,7 +16,7 @@ def test_request_with_x_correlation_id(bearer_token_int, correlation_id, method,
     .. include:: ../../partials/headers/test_request_with_x_correlation_id.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{endpoints}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "x-correlation-id": correlation_id
     })
 

--- a/tests/integration/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/integration/message_batches/create_message_batches/test_field_validation.py
@@ -24,7 +24,7 @@ def test_invalid_body(bearer_token_int, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         data="{}SF{}NOTVALID",
     )
@@ -52,7 +52,7 @@ def test_property_missing(bearer_token_int, property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json=Permutations.new_dict_without_key(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -83,7 +83,7 @@ def test_data_null(bearer_token_int, property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json=Permutations.new_dict_with_null_key(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -114,7 +114,7 @@ def test_data_invalid(bearer_token_int, property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -151,7 +151,7 @@ def test_data_duplicate(bearer_token_int, property, pointer, correlation_id):
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json=data,
     )
@@ -179,7 +179,7 @@ def test_data_too_few_items(bearer_token_int, property, pointer, correlation_id)
         headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body("int"),
@@ -206,7 +206,7 @@ def test_invalid_nhs_number(bearer_token_int, nhs_number, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -245,7 +245,7 @@ def test_invalid_dob(bearer_token_int, dob, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -283,7 +283,7 @@ def test_invalid_routing_plan(bearer_token_int, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -321,7 +321,7 @@ def test_invalid_message_batch_reference(bearer_token_int, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -359,7 +359,7 @@ def test_invalid_message_reference(bearer_token_int, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -398,7 +398,7 @@ def test_blank_value_under_messages(bearer_token_int, invalid_value, correlation
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -429,7 +429,7 @@ def test_null_value_under_messages(bearer_token_int, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -461,7 +461,7 @@ def test_invalid_personalisation(bearer_token_int, correlation_id, personalisati
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -500,7 +500,7 @@ def test_null_personalisation(bearer_token_int, correlation_id, personalisation)
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json={
         "data": {
             "type": "MessageBatch",

--- a/tests/integration/message_batches/create_message_batches/test_invalid_routing_plan.py
+++ b/tests/integration/message_batches/create_message_batches/test_invalid_routing_plan.py
@@ -24,7 +24,7 @@ def test_no_such_routing_plan(bearer_token_int, correlation_id):
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         }, json={
         "data": {
             "type": "MessageBatch",
@@ -62,7 +62,7 @@ def test_routing_plan_not_belonging_to_client_id(bearer_token_int, correlation_i
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         }, json={
         "data": {
             "type": "MessageBatch",
@@ -100,7 +100,7 @@ def test_routing_plan_missing_templates(bearer_token_int, correlation_id, routin
     """
     resp = requests.post(f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
             **headers,
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "X-Correlation-Id": correlation_id
         }, json={
         "data": {

--- a/tests/integration/message_batches/create_message_batches/test_performance.py
+++ b/tests/integration/message_batches/create_message_batches/test_performance.py
@@ -31,7 +31,7 @@ def test_create_messages_large_invalid_payload(bearer_token_int):
     resp = requests.post(f"{INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)
@@ -60,7 +60,7 @@ def test_create_messages_large_not_unique_payload(bearer_token_int):
     resp = requests.post(f"{INT_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": CONTENT_TYPE,
         "Content-Type": CONTENT_TYPE,
-        "Authorization": bearer_token_int
+        "Authorization": bearer_token_int.value
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)

--- a/tests/integration/message_batches/create_message_batches/test_success.py
+++ b/tests/integration/message_batches/create_message_batches/test_success.py
@@ -18,7 +18,7 @@ def test_201_message_batch_valid_accept_headers(bearer_token_int, accept_headers
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": accept_headers,
             "Content-Type": "application/json",
         },
@@ -42,7 +42,7 @@ def test_201_message_batch_valid_content_type_headers(bearer_token_int, content_
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": content_type,
         },
@@ -65,7 +65,7 @@ def test_201_message_batch_valid_nhs_number(bearer_token_int):
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -90,7 +90,7 @@ def test_201_message_batch_valid_dob(bearer_token_int, dob):
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -114,7 +114,7 @@ def test_request_without_dob(bearer_token_int):
     resp = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -137,7 +137,7 @@ def test_201_message_batches_request_idempotency(bearer_token_int):
     respOne = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },
@@ -149,7 +149,7 @@ def test_201_message_batches_request_idempotency(bearer_token_int):
     respTwo = requests.post(
         f"{constants.INT_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json",
         },

--- a/tests/integration/messages/create_messages/test_field_validation.py
+++ b/tests/integration/messages/create_messages/test_field_validation.py
@@ -24,7 +24,7 @@ def test_invalid_body(bearer_token_int, correlation_id):
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -52,7 +52,7 @@ def test_property_missing(bearer_token_int, property, pointer, correlation_id):
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -83,7 +83,7 @@ def test_data_null(bearer_token_int, property, pointer, correlation_id):
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -114,7 +114,7 @@ def test_data_invalid(bearer_token_int, property, pointer, correlation_id):
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             **headers,
             "X-Correlation-Id": correlation_id
         },
@@ -141,7 +141,7 @@ def test_invalid_nhs_number(bearer_token_int, nhs_number, correlation_id):
     .. include:: ../../partials/validation/test_invalid_nhs_number.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -176,7 +176,7 @@ def test_invalid_dob(bearer_token_int, dob, correlation_id):
     .. include:: ../../partials/validation/test_invalid_dob.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -210,7 +210,7 @@ def test_invalid_routing_plan(bearer_token_int, correlation_id):
     .. include:: ../../partials/validation/test_invalid_routing_plan.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -244,7 +244,7 @@ def test_invalid_message_reference(bearer_token_int, correlation_id):
     .. include:: ../../partials/validation/test_invalid_message_reference.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -279,7 +279,7 @@ def test_invalid_personalisation(bearer_token_int, correlation_id, personalisati
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={
@@ -313,7 +313,7 @@ def test_null_personalisation(bearer_token_int, correlation_id, personalisation)
     .. include:: ../../partials/validation/test_invalid_personalisation.rst
     """
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         **headers,
         "X-Correlation-Id": correlation_id
     }, json={

--- a/tests/integration/messages/create_messages/test_invalid_routing_plan.py
+++ b/tests/integration/messages/create_messages/test_invalid_routing_plan.py
@@ -25,7 +25,7 @@ def test_no_such_routing_plan(bearer_token_int, correlation_id):
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json={
             "data": {
@@ -60,7 +60,7 @@ def test_routing_plan_not_belonging_to_client_id(bearer_token_int, correlation_i
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         },
         json={
             "data": {
@@ -96,7 +96,7 @@ def test_routing_plan_missing_templates(bearer_token_int, correlation_id, routin
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
             **headers,
             "X-Correlation-Id": correlation_id,
-            "Authorization": bearer_token_int
+            "Authorization": bearer_token_int.value
         }, json={
         "data": {
             "type": "Message",

--- a/tests/integration/messages/create_messages/test_success.py
+++ b/tests/integration/messages/create_messages/test_success.py
@@ -18,7 +18,7 @@ def test_201_single_message_with_valid_accept_headers(bearer_token_int, accept_h
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": accept_headers,
             "Content-Type": "application/json"
         },
@@ -35,7 +35,7 @@ def test_201_single_message_with_valid_content_type_headers(bearer_token_int, co
     """
     data = Generators.generate_valid_create_message_body("int")
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": content_type
         }, json=data
@@ -52,7 +52,7 @@ def test_201_single_message_with_valid_nhs_number(bearer_token_int):
     data["data"]["attributes"]["recipient"]["nhsNumber"] = VALID_NHS_NUMBER
 
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json"
         }, json=data
@@ -70,7 +70,7 @@ def test_201_single_message_with_valid_dob(bearer_token_int, dob):
     data["data"]["attributes"]["recipient"]["dateOfBirth"] = dob
 
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-            "Authorization": bearer_token_int,
+            "Authorization": bearer_token_int.value,
             "Accept": "application/json",
             "Content-Type": "application/json"
         }, json=data
@@ -87,7 +87,7 @@ def test_single_message_request_without_dob(bearer_token_int):
     data["data"]["attributes"]["recipient"].pop("dateOfBirth")
 
     resp = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "application/json",
         "Content-Type": "application/json"
         }, json=data
@@ -103,7 +103,7 @@ def test_201_message_request_idempotency(bearer_token_int):
     data = Generators.generate_valid_create_message_body("int")
 
     respOne = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "application/json",
         "Content-Type": "application/json"
         }, json=data
@@ -112,7 +112,7 @@ def test_201_message_request_idempotency(bearer_token_int):
     time.sleep(5)
 
     respTwo = requests.post(f"{INT_URL}{MESSAGES_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "Accept": "application/json",
         "Content-Type": "application/json"
         }, json=data

--- a/tests/integration/messages/get_message/test_404.py
+++ b/tests/integration/messages/get_message/test_404.py
@@ -14,7 +14,7 @@ def test_message_id_not_belonging_to_client_id(bearer_token_int):
     """
     resp = requests.get(
         f"{INT_URL}{MESSAGES_ENDPOINT}/{MESSAGE_ID_NOT_BELONGING_TO_CLIENT}",
-        headers={"Authorization": bearer_token_int}
+        headers={"Authorization": bearer_token_int.value}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,
@@ -31,7 +31,7 @@ def test_message_id_that_does_not_exist(bearer_token_int):
     """
     resp = requests.get(
         f"{INT_URL}{MESSAGES_ENDPOINT}/does_not_exist",
-        headers={"Authorization": bearer_token_int}
+        headers={"Authorization": bearer_token_int.value}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/integration/messages/get_message/test_success.py
+++ b/tests/integration/messages/get_message/test_success.py
@@ -15,7 +15,7 @@ def test_200_get_message(bearer_token_int, message_ids):
     """
     resp = requests.get(
         f"{INT_URL}{MESSAGES_ENDPOINT}/{message_ids}",
-        headers={"Authorization": bearer_token_int}
+        headers={"Authorization": bearer_token_int.value}
         )
     Assertions.assert_200_response_message(resp, INT_URL)
     Assertions.assert_get_message_response_channels(resp, "email", "delivered")

--- a/tests/integration/nhsapp_accounts/test_400.py
+++ b/tests/integration/nhsapp_accounts/test_400.py
@@ -16,7 +16,7 @@ def test_400_missing_ods_code(bearer_token_int, page, correlation_id):
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_missing_ods_code.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -40,7 +40,7 @@ def test_400_invalid_ods_code(bearer_token_int, ods_code, correlation_id):
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_ods_code.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -65,7 +65,7 @@ def test_400_invalid_page(bearer_token_int, ods_code, page, correlation_id):
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_page.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/integration/nhsapp_accounts/test_404.py
+++ b/tests/integration/nhsapp_accounts/test_404.py
@@ -19,7 +19,7 @@ def test_404_page_not_found(bearer_token_int, ods_code, page, correlation_id):
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_page_not_found.rst
     """
     resp = requests.get(f"{constants.INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/integration/nhsapp_accounts/test_success.py
+++ b/tests/integration/nhsapp_accounts/test_success.py
@@ -17,7 +17,7 @@ def test_single_page(bearer_token_int, ods_code, page, correlation_id):
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_single_page.rst
     """
     resp = requests.get(f"{INT_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/integration/test_404_errors.py
+++ b/tests/integration/test_404_errors.py
@@ -16,7 +16,7 @@ def test_404_not_found(bearer_token_int, request_path, correlation_id, method):
     .. include:: ../../partials/not_found/test_404_not_found.rst
     """
     resp = getattr(requests, method)(f"{INT_URL}{request_path}", headers={
-        "Authorization": bearer_token_int,
+        "Authorization": bearer_token_int.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "*/*",
         "Content-Type": "application/json"

--- a/tests/lib/authentication.py
+++ b/tests/lib/authentication.py
@@ -4,6 +4,7 @@ import os
 import jwt
 import requests
 import json
+from .secret import Secret
 
 
 class AuthenticationCache():
@@ -63,4 +64,4 @@ class AuthenticationCache():
             self.tokens[env] = (f"Bearer {details.get('access_token')}", int(time()))
 
         bearer_token = self.tokens[env][0]
-        return bearer_token
+        return Secret(bearer_token)

--- a/tests/lib/secret.py
+++ b/tests/lib/secret.py
@@ -1,0 +1,9 @@
+class Secret:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return "Secret(********)"
+
+    def __str___(self):
+        return "*******"

--- a/tests/production/content_types/test_406_errors.py
+++ b/tests/production/content_types/test_406_errors.py
@@ -14,7 +14,7 @@ def test_406(bearer_token_prod, method, endpoints):
     """
     resp = getattr(requests, method)(f"{PROD_URL}/{endpoints}", headers={
         "Accept": "invalid",
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
     })
 
     Assertions.assert_error_with_optional_correlation_id(

--- a/tests/production/content_types/test_415_errors.py
+++ b/tests/production/content_types/test_415_errors.py
@@ -15,7 +15,7 @@ def test_415_invalid(bearer_token_prod, method, endpoints):
     .. include:: ../../partials/content_types/test_415_invalid.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "Accept": "application/json",
         "Content-Type": "invalid"
         })

--- a/tests/production/content_types/test_content_type_negotiation.py
+++ b/tests/production/content_types/test_content_type_negotiation.py
@@ -35,7 +35,7 @@ def test_application_response_type(bearer_token_prod, accept_headers, method, en
     .. include:: ../../partials/content_types/test_application_response_type.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         **accept_headers.get("headers")
     })
 

--- a/tests/production/headers/test_cors.py
+++ b/tests/production/headers/test_cors.py
@@ -16,7 +16,7 @@ def test_cors_options(bearer_token_prod, method, endpoints):
     .. include :: ../../partials/headers/test_cors_options.rst
     """
     resp = requests.options(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method
@@ -32,7 +32,7 @@ def test_cors(bearer_token_prod, method, endpoints):
     .. include :: ../../partials/headers/test_cors.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{endpoints}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "Accept": "*/*",
         "Origin": ORIGIN
     })

--- a/tests/production/headers/test_x_amz_removal.py
+++ b/tests/production/headers/test_x_amz_removal.py
@@ -12,7 +12,7 @@ from lib.fixtures import *
 def test_request_with_x_amz_is_removed(bearer_token_prod, nhsd_apim_proxy_url, endpoints, method):
 
     resp = getattr(requests, method)(f"{nhsd_apim_proxy_url}/{endpoints}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "Accept": "*/*",
         "Origin": ORIGIN,
         "Access-Control-Request-Method": method

--- a/tests/production/headers/test_x_correlation_id.py
+++ b/tests/production/headers/test_x_correlation_id.py
@@ -20,7 +20,7 @@ def test_request_with_x_correlation_id(
     .. include:: ../../partials/headers/test_request_with_x_correlation_id.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "x-correlation-id": correlation_id
     })
 

--- a/tests/production/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/production/message_batches/create_message_batches/test_field_validation.py
@@ -25,7 +25,7 @@ def test_invalid_body(bearer_token_prod):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         data="{}SF{}NOTVALID",
     )
@@ -48,7 +48,7 @@ def test_property_missing(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_without_key(
             Generators.generate_valid_create_message_batch_body(),
@@ -74,7 +74,7 @@ def test_data_null(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_null_key(
             Generators.generate_valid_create_message_batch_body(),
@@ -100,7 +100,7 @@ def test_data_invalid(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body(),
@@ -132,7 +132,7 @@ def test_data_duplicate(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=data,
     )
@@ -155,7 +155,7 @@ def test_data_too_few_items(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_batch_body(),
@@ -180,7 +180,7 @@ def test_invalid_nhs_number(bearer_token_prod, nhs_number):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -217,7 +217,7 @@ def test_invalid_dob(bearer_token_prod, dob):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -253,7 +253,7 @@ def test_invalid_routing_plan(bearer_token_prod):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -289,7 +289,7 @@ def test_invalid_message_batch_reference(bearer_token_prod):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -325,7 +325,7 @@ def test_invalid_message_reference(bearer_token_prod):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -362,7 +362,7 @@ def test_blank_value_under_messages(bearer_token_prod, invalid_value):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -391,7 +391,7 @@ def test_null_value_under_messages(bearer_token_prod):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -421,7 +421,7 @@ def test_invalid_personalisation(bearer_token_prod, personalisation):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -458,7 +458,7 @@ def test_null_personalisation(bearer_token_prod, personalisation):
     """
     resp = requests.post(f"{constants.PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json={
         "data": {
             "type": "MessageBatch",

--- a/tests/production/message_batches/create_message_batches/test_invalid_routing_config.py
+++ b/tests/production/message_batches/create_message_batches/test_invalid_routing_config.py
@@ -15,7 +15,7 @@ def test_no_such_routing_plan(bearer_token_prod):
     .. include:: ../../partials/invalid_routing_plans/test_no_such_routing_plan.rst
     """
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
     }, json={
         "data": {
             "type": "MessageBatch",
@@ -50,7 +50,7 @@ def test_routing_plan_not_belonging_to_client_id(bearer_token_prod):
     .. include:: ../../partials/invalid_routing_plans/test_routing_plan_not_belonging_to_client_id.rst
     """
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
     }, json={
         "data": {
             "type": "MessageBatch",

--- a/tests/production/message_batches/create_message_batches/test_performance.py
+++ b/tests/production/message_batches/create_message_batches/test_performance.py
@@ -30,7 +30,7 @@ def test_create_messages_large_invalid_payload(bearer_token_prod):
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)
@@ -59,7 +59,7 @@ def test_create_messages_large_not_unique_payload(bearer_token_prod):
     resp = requests.post(f"{PROD_URL}{MESSAGE_BATCHES_ENDPOINT}", headers={
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "Authorization": bearer_token_prod
+        "Authorization": bearer_token_prod.value
     }, json=data
     )
     Assertions.assert_error_with_optional_correlation_id(resp, 400, None, None)

--- a/tests/production/messages/create_messages/test_field_validation.py
+++ b/tests/production/messages/create_messages/test_field_validation.py
@@ -21,7 +21,7 @@ def test_invalid_body(bearer_token_prod):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         data="{}SF{}NOTVALID",
     )
@@ -47,7 +47,7 @@ def test_property_missing(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_without_key(
             Generators.generate_valid_create_message_body("prod"),
@@ -76,7 +76,7 @@ def test_data_null(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_null_key(
             Generators.generate_valid_create_message_body("prod"),
@@ -105,7 +105,7 @@ def test_data_invalid(bearer_token_prod, property, pointer):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -132,7 +132,7 @@ def test_invalid_nhs_number(bearer_token_prod, nhs_number):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -159,7 +159,7 @@ def test_invalid_dob(bearer_token_prod, dob):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -185,7 +185,7 @@ def test_invalid_routing_plan(bearer_token_prod):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -211,7 +211,7 @@ def test_invalid_message_reference(bearer_token_prod):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -238,7 +238,7 @@ def test_invalid_personalisation(bearer_token_prod, personalisation):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -265,7 +265,7 @@ def test_null_personalisation(bearer_token_prod, personalisation):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),

--- a/tests/production/messages/create_messages/test_invalid_routing_plan.py
+++ b/tests/production/messages/create_messages/test_invalid_routing_plan.py
@@ -23,7 +23,7 @@ def test_no_such_routing_plan(bearer_token_prod):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),
@@ -49,7 +49,7 @@ def test_routing_plan_not_belonging_to_client_id(bearer_token_prod):
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
             **headers,
-            "Authorization": bearer_token_prod
+            "Authorization": bearer_token_prod.value
         },
         json=Permutations.new_dict_with_new_value(
             Generators.generate_valid_create_message_body("prod"),

--- a/tests/production/messages/get_message/test_404.py
+++ b/tests/production/messages/get_message/test_404.py
@@ -14,7 +14,7 @@ def test_message_id_not_belonging_to_client_id(bearer_token_prod):
     """
     resp = requests.get(
         f"{PROD_URL}{MESSAGES_ENDPOINT}/{MESSAGE_ID_NOT_BELONGING_TO_CLIENT}",
-        headers={"Authorization": bearer_token_prod}
+        headers={"Authorization": bearer_token_prod.value}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,
@@ -31,7 +31,7 @@ def test_message_id_that_does_not_exist(bearer_token_prod):
     """
     resp = requests.get(
         f"{PROD_URL}{MESSAGES_ENDPOINT}/does_not_exist",
-        headers={"Authorization": bearer_token_prod}
+        headers={"Authorization": bearer_token_prod.value}
         )
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/production/messages/get_message/test_success.py
+++ b/tests/production/messages/get_message/test_success.py
@@ -16,7 +16,7 @@ def test_200_get_message(bearer_token_prod, message_ids):
     """
     resp = requests.get(
         f"{PROD_URL}{MESSAGES_ENDPOINT}/{message_ids}",
-        headers={"Authorization": bearer_token_prod}
+        headers={"Authorization": bearer_token_prod.value}
         )
     Assertions.assert_200_response_message(resp, PROD_URL)
     Assertions.assert_get_message_response_channels(resp, "email", "delivered")

--- a/tests/production/nhsapp_accounts/test_400.py
+++ b/tests/production/nhsapp_accounts/test_400.py
@@ -16,7 +16,7 @@ def test_400_missing_ods_code(bearer_token_prod, page, correlation_id):
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_missing_ods_code.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -40,7 +40,7 @@ def test_400_invalid_ods_code(bearer_token_prod, ods_code, correlation_id):
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_ods_code.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -65,7 +65,7 @@ def test_400_invalid_page(bearer_token_prod, ods_code, page, correlation_id):
     .. include:: ../../partials/invalid_ods_code/test_400_nhsapp_accounts_invalid_page.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/production/nhsapp_accounts/test_404.py
+++ b/tests/production/nhsapp_accounts/test_404.py
@@ -19,7 +19,7 @@ def test_404_page_not_found(bearer_token_prod, ods_code, page, correlation_id):
     .. include:: ../../partials/not_found/test_404_nhsapp_accounts_page_not_found.rst
     """
     resp = requests.get(f"{constants.PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/production/nhsapp_accounts/test_success.py
+++ b/tests/production/nhsapp_accounts/test_success.py
@@ -18,7 +18,7 @@ def test_single_page(bearer_token_prod, ods_code, page, correlation_id):
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_single_page.rst
     """
     resp = requests.get(f"{PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={
@@ -39,7 +39,7 @@ def test_multi_pages(bearer_token_prod, ods_code, page, correlation_id):
     .. include:: ../../partials/happy_path/test_200_get_nhsapp_accounts_multi_pages.rst
     """
     resp = requests.get(f"{PROD_URL}{NHSAPP_ACCOUNTS_ENDPOINT}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "X-Correlation-Id": correlation_id,
         "Accept": "application/vnd.api+json"
     }, params={

--- a/tests/production/test_404_errors.py
+++ b/tests/production/test_404_errors.py
@@ -16,7 +16,7 @@ def test_404_not_found(bearer_token_prod, request_path, method):
     .. include:: ../../partials/not_found/test_404_not_found.rst
     """
     resp = getattr(requests, method)(f"{PROD_URL}{request_path}", headers={
-        "Authorization": bearer_token_prod,
+        "Authorization": bearer_token_prod.value,
         "Accept": "*/*",
         "Content-Type": "application/json"
     })


### PR DESCRIPTION
## Summary
This update is to hide bearer tokens from the logs when a test fails. The logs now show `Secret(********)` instead of the actual token.

This has been tested by breaking an internal-dev test:
![image](https://github.com/NHSDigital/communications-manager-api/assets/156111959/8c2c01f6-e286-4e12-aa51-ac4f74c53f7e)



## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
