### PR TITLE
CCM-5798: Update channel status callback doc

### DIFF
--- a/specification/callbacks/channel-subscription-openapi-spec.json
+++ b/specification/callbacks/channel-subscription-openapi-spec.json
@@ -11,7 +11,7 @@
     }
   ],
   "paths": {
-    "/nhs-notify-callbacks/v1/message-status": {
+    "/nhs-notify-callbacks/v1/channel-status": {
       "post": {
         "summary": "Receive a callback",
         "description": "You may develop this endpoint on your service if you want to receive callbacks from NHS Notify.\n\nWe have created an OpenAPI specification detailing the behaviour of the endpoint that consumers should create to subscribe to callbacks.\n\nWe will send your API key in the `x-api-key` header. Your service should respond with:\n\n* `401 Unauthorized` if the API key is not received\n* `401 Unauthorized` if the API key is invalid\n\nWe will send you a HMAC-SHA256 signature in the `x-hmac-sha256-signature` header. You will need to validate the signature to verify the response has come from an authorized sender. Details on this will be provided during the onboarding process. If you receive a request with an invalid signature you should ignore it and respond with a `403 Forbidden`.\n\nEvery request includes an idempotencyKey located in the meta collection of the body. This can help ensure your system remains idempotent, capable of managing duplicate delivery of callbacks. It's important to note that requests may be delivered non-sequentially.\n\nIf a request fails, our retry policy will make up to three attempts with intervals of five seconds between each attempt.\n\nThe default behaviour of NHS Notify will make a callback to this endpoint when:\n\n* the message has been delivered (via any channel)\n* the message could not be delivered to a given channel (but may be deliverable by an alternative channel)\n* the message could not be delivered by any channel\n\nCallbacks can be received for additional state transitions subject to the needs of the user. These additional state transitions can be requested during onboarding. These statuses are:\n\n* `pending_enrichment` - the message is currently pending enrichment\n* `enriched` - we have queried PDS for this patient's details and now know how to contact this individual\n* `sending` - the message is in the process of being sent",
@@ -110,7 +110,7 @@
                 "description": "The current status of this channel at the time this response was generated.",
                 "$ref": "#/components/schemas/Enum_ChannelStatus"
               },
-              "messageStatusDescription": {
+              "channelStatusDescription": {
                 "type": "string",
                 "description": "If there is extra information associated with the status of this channel, it is provided here."
               },

--- a/specification/schemas/components/SupplierStatus.yaml
+++ b/specification/schemas/components/SupplierStatus.yaml
@@ -23,7 +23,7 @@ properties:
       channelStatus:
         description: The current status of this channel at the time this response was generated.
         $ref: ../enums/ChannelStatus.yaml
-      messageStatusDescription:
+      channelStatusDescription:
         type: string
         description: If there is extra information associated with the status of this channel, it is provided here.
         example: ""


### PR DESCRIPTION
## Summary
Trivial update to the documentation for channel status callbacks: `messageStatusDescription` -> `channelStatusDescription`

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
