### PR TITLE
CCM-5754: Fail zap pipeline when error in bash

### DIFF
--- a/azure/nightly-zap-scan-pipeline.yml
+++ b/azure/nightly-zap-scan-pipeline.yml
@@ -41,7 +41,6 @@ steps:
     parameters:
       webhook_uri: 'ALERTS_DEV_API_WEBHOOK_URI'
   - bash: |
-      set -e
       export INTEGRATION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(INTEGRATION_PRIVATE_KEY)"
       export INTEGRATION_API_KEY="$(INTEGRATION_API_KEY)"
       make install-python && make zap-security-scan    

--- a/azure/nightly-zap-scan-pipeline.yml
+++ b/azure/nightly-zap-scan-pipeline.yml
@@ -41,6 +41,7 @@ steps:
     parameters:
       webhook_uri: 'ALERTS_DEV_API_WEBHOOK_URI'
   - bash: |
+      set -e
       export INTEGRATION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(INTEGRATION_PRIVATE_KEY)"
       export INTEGRATION_API_KEY="$(INTEGRATION_API_KEY)"
       make install-python && make zap-security-scan    

--- a/scripts/publish_zap_compatible.py
+++ b/scripts/publish_zap_compatible.py
@@ -35,7 +35,8 @@ with open('build/communications-manager-zap.json', 'w') as f:
             (
                 ("format", "date"),
                 ("personalisation", None),
-                ("/callbacks", None)
+                ("/callbacks/message-status", None),
+                ("/<client-provided-URI>", None),
             )
         ),
         f

--- a/scripts/run_zap.sh
+++ b/scripts/run_zap.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-set -o nounset errexit pipefail
-set -e
+set -o nounset
+set -o errexit
+set -o pipefail
 
 # create our temporary directory
 export TEMP_DIR=/tmp

--- a/scripts/run_zap.sh
+++ b/scripts/run_zap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -o nounset errexit pipefail
+set -e
 
 # create our temporary directory
 export TEMP_DIR=/tmp

--- a/specification/schemas/components/SupplierStatus.yaml
+++ b/specification/schemas/components/SupplierStatus.yaml
@@ -28,7 +28,7 @@ properties:
         description: If there is extra information associated with the status of this channel, it is provided here.
         example: ""
       supplierStatus:
-        $ref: ../enums/SupplierStatus.yaml
+        $ref: ../enums/SupplierStatusEnum.yaml
       timestamp:
         type: string
         description: Date-time for when the supplier status change was processed.

--- a/specification/schemas/enums/MessageStatusEnum.yaml
+++ b/specification/schemas/enums/MessageStatusEnum.yaml
@@ -1,4 +1,4 @@
-title: Enum_MessageStatus
+title: MessageStatusEnum
 type: string
 enum:
   - created

--- a/specification/schemas/enums/MessageStatusEnum.yaml
+++ b/specification/schemas/enums/MessageStatusEnum.yaml
@@ -1,4 +1,4 @@
-title: MessageStatusEnum
+title: Enum_MessageStatus
 type: string
 enum:
   - created

--- a/specification/schemas/enums/SupplierStatusEnum.yaml
+++ b/specification/schemas/enums/SupplierStatusEnum.yaml
@@ -1,4 +1,4 @@
-title: Enum_SupplierStatus
+title: SupplierStatusEnum
 type: string
 enum:
   - delivered

--- a/specification/schemas/enums/SupplierStatusEnum.yaml
+++ b/specification/schemas/enums/SupplierStatusEnum.yaml
@@ -1,4 +1,4 @@
-title: SupplierStatusEnum
+title: Enum_SupplierStatus
 type: string
 enum:
   - delivered

--- a/specification/schemas/responses/MessageResponse.yaml
+++ b/specification/schemas/responses/MessageResponse.yaml
@@ -23,7 +23,7 @@ properties:
               The current status of this message at the time this response was generated.
 
               For more information please check our documentation on message & channel statuses above.
-            $ref: ../enums/MessageStatus.yaml
+            $ref: ../enums/MessageStatusEnum.yaml
           messageStatusDescription:
             type: string
             description: If there is extra information associated with the status of this message, it is provided here.
@@ -61,7 +61,7 @@ properties:
                     The current status of this message within the channel at the time this response was generated.
       
                     For more information please check our documentation on message & channel statuses above.
-                  $ref: ../enums/SupplierStatus.yaml
+                  $ref: ../enums/SupplierStatusEnum.yaml
                 timestamps:
                   type: object
                   additionalProperties: false

--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -1,3 +1,3 @@
-FROM softwaresecurityproject/zap-stable:2.15.0
+FROM softwaresecurityproject/zap-stable:2.14.0
 
 COPY ./zap/policies/ /home/zap/.ZAP/policies/


### PR DESCRIPTION
## Summary
Updates to the Zap scan:
- Update bash script to exit on a failure. The zap scan is run inside a docker container and if it failed then the script would go on and the pipeline would still show as green.
- Update the openapi specs used by zap in order to exclude the callback URLs defined in the documentation. The 4 endpoints scanned are now: Get Message, Post Message, Post Batch and Get NHS App Accounts.
- Update the definition of the SupplierStatus and ChannelStatus enums to have a unique file name. This was causing a warning followed by an automatic appending of the suffix "-2"
- Use the previous version of zap: 2.14.0. The current version 2.15.0 is causing some errors that I believe are from the jython script `zap/scripts/authentication/get_bearer_token.js` but I couldn't get to the bottom of them. https://nhsd-jira.digital.nhs.uk/browse/CCM-5987 raised to look into it.

This is now the output of the scan:
![image](https://github.com/user-attachments/assets/ee36d815-29e8-4dcc-ac60-55678dcddb8f)

Note that the errors `[Fatal Error] :1:1: Content is not allowed in prolog.` are a red herring and can be ignored. Each scan is only run once.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
