### PR TITLE
CCM-5995 / CCM-5951 / CCM-5561 / CCM-5937 / CCM-5132 API Documentation Fixes

### DIFF
--- a/scripts/publish_zap_compatible.py
+++ b/scripts/publish_zap_compatible.py
@@ -35,8 +35,8 @@ with open('build/communications-manager-zap.json', 'w') as f:
             (
                 ("format", "date"),
                 ("personalisation", None),
-                ("/callbacks/message-status", None),
-                ("/<client-provided-URI>", None),
+                ("/<client-provided-message-status-URI>", None),
+                ("/<client-provided-channel-status-URI>", None),
             )
         ),
         f

--- a/specification/callbacks/channel-subscription-openapi-spec.json
+++ b/specification/callbacks/channel-subscription-openapi-spec.json
@@ -123,8 +123,7 @@
                 "format": "date-time"
               },
               "retryCount": {
-                "type": "number",
-                "description": "Contains the amount of times that we have attempted to send this channel."
+                "$ref": "../snippets/RetryCount.yaml"
               }
             },
             "required": [

--- a/specification/callbacks/channel_status.yaml
+++ b/specification/callbacks/channel_status.yaml
@@ -2,7 +2,7 @@
 summary: Channel Status
 description: |-
 
-    NHS Notify can send a supplier status callback when:
+    NHS Notify can send a channel status callback when:
     * the channel status has changed - This refers to the internal statuses used by NHS Notify, which are consistent across all channels
     * the supplier status has changed - This is the raw status value specified by the underlying channel supplier. The possible values are listed [here](#overview--supplier-statuses)
 

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -48,11 +48,11 @@ paths:
         description: The ordinal number of the page of results to be retrieved. If omitted, the first page of results will be returned. Use the links section in the response body to determine whether any further pages of results exist.
     get:
       $ref: endpoints/get_nhsapp_account_details.yaml
-  /callbacks/message-status:
+  /<client-provided-message-status-URI>:
     post:
       $ref: callbacks/message_status.yaml
       tags: ['Callbacks']
-  /<client-provided-URI>:
+  /<client-provided-channel-status-URI>:
     post:
       $ref: callbacks/channel_status.yaml
       tags: ['Callbacks']

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -46,7 +46,7 @@ This API can generate responses in the following formats:
 
 Both of these formats have the same structure - the API responds with a standard JSON document.
 
-You can control which `Content-Type` is returned by using the `Accept` header.
+You can use the `Accept` header to control which `Content-Type` is returned in the response.
 
 The `Accept` header can contain the following values:
 

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -191,7 +191,7 @@ The message status shows an overall aggregate status taken from all of the commu
 
 The channels can have the following supplier statuses:
 
-### NHS APP
+### NHS App
 
 * `delivered` - the message has been successfully delivered to the user
 * `read` - a user has read the message

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -52,14 +52,18 @@ The `Accept` header can contain the following values:
 * `application/json`
 * `application/vnd.api+json`
 
+The `Accept` header may optionally include a `charset` attribute. If included, it **must** be set to `charset=utf-8` Any other `charset` value will result in a `415` error response. If ommited then `utf-8` is assumed. 
+
 Where no `Accept` header is present, this will default to `application/vnd.api+json`
 
-### Request Content Types
+### Request content types
 
 This API will accept request payloads of the following types:
 
 * `application/vnd.api+json` - see [JSON:API specification](https://jsonapi.org/format/#introduction)
 * `application/json`
+
+The `Content-Type` header may optionally include a `charset` attribute. If included, it **must** be set to `charset=utf-8` Any other `charset` value will result in a `406` error response. If ommited then `utf-8` is assumed. 
 
 If you attempt to send a payload without the `Content-Type` header set to either of these values then the API will respond with a `415 Unsupported Media Type` response.
 

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -19,6 +19,8 @@ The NHS Notify service is intended for services involved in direct care. This AP
 
 This API is [in production, beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#statuses). We are onboarding partners to use it.
 
+We may make additive non-breaking changes to the API without notice, for example the addition of fields to the response, or new optional fields to the request.
+
 You can comment, upvote and view progress on [our roadmap](https://nhs-digital-api-management.featureupvote.com/?order=top&filter=allexceptdone&tag=nhs-notify-api).
 
 If you have any other queries, [contact us](https://digital.nhs.uk/developer/help-and-support).

--- a/specification/schemas/components/MessageStatus.yaml
+++ b/specification/schemas/components/MessageStatus.yaml
@@ -15,7 +15,7 @@ properties:
           - 1642109b-69eb-447f-8f97-ab70a74f5db4
       messageStatus:
         type: string
-        $ref: ../enums/MessageStatus.yaml 
+        $ref: ../enums/EnumMessageStatus.yaml 
       messageStatusDescription:
         type: string
         example: ""

--- a/specification/schemas/components/MessageStatus.yaml
+++ b/specification/schemas/components/MessageStatus.yaml
@@ -15,7 +15,7 @@ properties:
           - 1642109b-69eb-447f-8f97-ab70a74f5db4
       messageStatus:
         type: string
-        $ref: ../enums/EnumMessageStatus.yaml 
+        $ref: ../enums/MessageStatusEnum.yaml 
       messageStatusDescription:
         type: string
         example: ""

--- a/specification/schemas/components/MessageStatus.yaml
+++ b/specification/schemas/components/MessageStatus.yaml
@@ -15,14 +15,7 @@ properties:
           - 1642109b-69eb-447f-8f97-ab70a74f5db4
       messageStatus:
         type: string
-        title: ChannelStatus
-        enum:
-          - pending_enrichment
-          - enriched
-          - sending
-          - delivered
-          - failed
-        example: delivered
+        $ref: ../enums/MessageStatus.yaml 
       messageStatusDescription:
         type: string
         example: ""

--- a/specification/schemas/components/SupplierStatus.yaml
+++ b/specification/schemas/components/SupplierStatus.yaml
@@ -21,14 +21,17 @@ properties:
           - nhsapp
         example: nhsapp
       channelStatus:
-        description: The current status of this channel at the time this response was generated.
         $ref: ../enums/ChannelStatus.yaml
       channelStatusDescription:
         type: string
         description: If there is extra information associated with the status of this channel, it is provided here.
         example: ""
       supplierStatus:
+<<<<<<< HEAD
         $ref: ../enums/SupplierStatusEnum.yaml
+=======
+        $ref: ../enums/SupplierStatus.yaml
+>>>>>>> b5567fa (CCM-5995: Add descriptions to enums in API docs)
       timestamp:
         type: string
         description: Date-time for when the supplier status change was processed.
@@ -36,7 +39,7 @@ properties:
         example: '2023-11-17T14:27:51.413Z'
       retryCount:
         type: number
-        description: Contains the amount of times that we have attempted to send this channel.
+        description: Contains the amount of times that we have attempted to send this message to this channel.
         example: 1
     required:
       - messageId

--- a/specification/schemas/components/SupplierStatus.yaml
+++ b/specification/schemas/components/SupplierStatus.yaml
@@ -7,7 +7,6 @@ properties:
     type: object
     properties:
       messageId:
-        description: Identifier for the message
         $ref: ../types/KSUID.yaml
       messageReference:
         type: string
@@ -27,20 +26,14 @@ properties:
         description: If there is extra information associated with the status of this channel, it is provided here.
         example: ""
       supplierStatus:
-<<<<<<< HEAD
         $ref: ../enums/SupplierStatusEnum.yaml
-=======
-        $ref: ../enums/SupplierStatus.yaml
->>>>>>> b5567fa (CCM-5995: Add descriptions to enums in API docs)
       timestamp:
         type: string
         description: Date-time for when the supplier status change was processed.
         format: date-time
         example: '2023-11-17T14:27:51.413Z'
       retryCount:
-        type: number
-        description: Contains the amount of times that we have attempted to send this message to this channel.
-        example: 1
+        $ref: ../../snippets/RetryCount.yaml
     required:
       - messageId
       - messageReference

--- a/specification/schemas/enums/ChannelStatus.yaml
+++ b/specification/schemas/enums/ChannelStatus.yaml
@@ -1,5 +1,6 @@
+title: Enum_ChannelStatus
+description: The current status of this channel at the time this response was generated.
 type: string
-title: ChannelStatus
 enum:
   - created
   - sending

--- a/specification/schemas/enums/ChannelType.yaml
+++ b/specification/schemas/enums/ChannelType.yaml
@@ -1,5 +1,6 @@
+title: Enum_ChannelType
+description: The communication type of this channel.
 type: string
-title: ChannelType
 enum:
   - nhsapp
   - email

--- a/specification/schemas/enums/EnumMessage.yaml
+++ b/specification/schemas/enums/EnumMessage.yaml
@@ -1,4 +1,4 @@
-title: Type_Message
+title: Enum_Message
 type: string
 enum:
   - Message

--- a/specification/schemas/enums/EnumMessageBatch.yaml
+++ b/specification/schemas/enums/EnumMessageBatch.yaml
@@ -1,4 +1,4 @@
-title: Type_MessageBatch
+title: Enum_MessageBatch
 type: string
 enum:
   - MessageBatch

--- a/specification/schemas/enums/ErrorAccessDenied.yaml
+++ b/specification/schemas/enums/ErrorAccessDenied.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_AccessDenied
 type: string
 enum:
   - CM_DENIED
 example: CM_DENIED
-title: Enum_Error_AccessDenied

--- a/specification/schemas/enums/ErrorBadGateway.yaml
+++ b/specification/schemas/enums/ErrorBadGateway.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_BadGateway
 type: string
 enum:
   - CM_BAD_GATEWAY
 example: CM_BAD_GATEWAY
-title: Enum_Error_BadGateway

--- a/specification/schemas/enums/ErrorCreateMessageInternalServerError.yaml
+++ b/specification/schemas/enums/ErrorCreateMessageInternalServerError.yaml
@@ -1,7 +1,7 @@
+title: Enum_Error_CreateMessageInternalServerError
 type: string
 enum:
   - CM_ROUTING_PLAN_DUPLICATE_TEMPLATES
   - CM_MISSING_ROUTING_PLAN_TEMPLATE
   - CM_INTERNAL_SERVER_ERROR
 example: CM_MISSING_ROUTING_PLAN_TEMPLATE
-title: Enum_Error_CreateMessageInternalServerError

--- a/specification/schemas/enums/ErrorForbidden.yaml
+++ b/specification/schemas/enums/ErrorForbidden.yaml
@@ -1,6 +1,6 @@
+title: Enum_Error_Forbidden
 type: string
 enum:
   - CM_FORBIDDEN
   - CM_SERVICE_BAN
 example: CM_FORBIDDEN
-title: Enum_Error_Forbidden

--- a/specification/schemas/enums/ErrorInternalServerError.yaml
+++ b/specification/schemas/enums/ErrorInternalServerError.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_InternalServerError
 type: string
 enum:
   - CM_INTERNAL_SERVER_ERROR
 example: CM_INTERNAL_SERVER_ERROR
-title: Enum_Error_InternalServerError

--- a/specification/schemas/enums/ErrorInvalidNHSNumber.yaml
+++ b/specification/schemas/enums/ErrorInvalidNHSNumber.yaml
@@ -1,3 +1,4 @@
+title: Enum_Error_InvalidNHSNumber
 type: string
 enum:
   - CM_MISSING_VALUE
@@ -9,4 +10,3 @@ enum:
   - CM_ODS_CODE_REQUIRED
   - CM_CANNOT_SET_ODS_CODE
 example: CM_INVALID_NHS_NUMBER
-title: Enum_Error_InvalidNHSNumber

--- a/specification/schemas/enums/ErrorInvalidValue.yaml
+++ b/specification/schemas/enums/ErrorInvalidValue.yaml
@@ -1,3 +1,4 @@
+title: Enum_Error_InvalidValue
 type: string
 enum:
   - CM_MISSING_VALUE
@@ -9,4 +10,3 @@ enum:
   - CM_ODS_CODE_REQUIRED
   - CM_CANNOT_SET_ODS_CODE
 example: CM_INVALID_VALUE
-title: Enum_Error_InvalidValue

--- a/specification/schemas/enums/ErrorMethodNotAllowed.yaml
+++ b/specification/schemas/enums/ErrorMethodNotAllowed.yaml
@@ -1,5 +1,5 @@
-type: string
 title: Enum_Error_Method_Not_Allowed
+type: string
 enum:
   - CM_NOT_ALLOWED
 example: CM_NOT_ALLOWED

--- a/specification/schemas/enums/ErrorNoSuchRoutingPlan.yaml
+++ b/specification/schemas/enums/ErrorNoSuchRoutingPlan.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_NoSuchRoutingPlan
 type: string
 enum:
   - CM_NO_SUCH_ROUTING_PLAN
 example: CM_NO_SUCH_ROUTING_PLAN
-title: Enum_Error_NoSuchRoutingPlan

--- a/specification/schemas/enums/ErrorNotAcceptable.yaml
+++ b/specification/schemas/enums/ErrorNotAcceptable.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_NotAcceptable
 type: string
 enum:
   - CM_NOT_ACCEPTABLE
-title: Enum_Error_NotAcceptable
 example: CM_NOT_ACCEPTABLE

--- a/specification/schemas/enums/ErrorNotFound.yaml
+++ b/specification/schemas/enums/ErrorNotFound.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_NotFound
 type: string
 enum:
   - CM_NOT_FOUND
 example: CM_NOT_FOUND
-title: Enum_Error_NotFound

--- a/specification/schemas/enums/ErrorQuota.yaml
+++ b/specification/schemas/enums/ErrorQuota.yaml
@@ -1,5 +1,5 @@
-type: string
 title: Enum_Error_Quota
+type: string
 enum:
   - CM_QUOTA
 example: CM_QUOTA

--- a/specification/schemas/enums/ErrorRetryTooEarly.yaml
+++ b/specification/schemas/enums/ErrorRetryTooEarly.yaml
@@ -1,5 +1,5 @@
-type: string
 title: Enum_Error_Retry_Too_Early
+type: string
 enum:
   - CM_RETRY_TOO_EARLY
 example: CM_RETRY_TOO_EARLY

--- a/specification/schemas/enums/ErrorServiceUnavailable.yaml
+++ b/specification/schemas/enums/ErrorServiceUnavailable.yaml
@@ -1,5 +1,5 @@
-type: string
 title: Enum_Error_ServiceUnavailable
+type: string
 enum:
   - CM_SERVICE_UNAVAILABLE
 example: CM_SERVICE_UNAVAILABLE

--- a/specification/schemas/enums/ErrorTimeout.yaml
+++ b/specification/schemas/enums/ErrorTimeout.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_Timeout
 type: string
 enum:
   - CM_TIMEOUT
-title: Enum_Error_Timeout
 example: CM_TIMEOUT

--- a/specification/schemas/enums/ErrorUnsupportedMedia.yaml
+++ b/specification/schemas/enums/ErrorUnsupportedMedia.yaml
@@ -1,5 +1,5 @@
+title: Enum_Error_UnsupportedMedia
 type: string
 enum:
   - CM_UNSUPPORTED_MEDIA
-title: Enum_Error_UnsupportedMedia
 example: CM_UNSUPPORTED_MEDIA

--- a/specification/schemas/enums/MessageStatusEnum.yaml
+++ b/specification/schemas/enums/MessageStatusEnum.yaml
@@ -1,4 +1,5 @@
 title: Enum_MessageStatus
+description: An overall aggregate status taken from all of the communication channels that we have attempted to deliver the message using.
 type: string
 enum:
   - created

--- a/specification/schemas/enums/MetadataLabels.yaml
+++ b/specification/schemas/enums/MetadataLabels.yaml
@@ -1,5 +1,5 @@
+title: Enum_MetadataLabels
 type: string
-title: MetadataLabels
 enum:
   - nhsapp
   - email

--- a/specification/schemas/enums/MetadataSources.yaml
+++ b/specification/schemas/enums/MetadataSources.yaml
@@ -1,5 +1,5 @@
+title: Enum_MetadataSources
 type: string
 enum:
   - pds
-title: MetadataSources
 example: pds

--- a/specification/schemas/enums/RoutingPlanType.yaml
+++ b/specification/schemas/enums/RoutingPlanType.yaml
@@ -1,5 +1,5 @@
+title: Enum_RoutingPlanType
 type: string
-title: RoutingPlanType
 enum:
   - original
   - override

--- a/specification/schemas/enums/SupplierStatusEnum.yaml
+++ b/specification/schemas/enums/SupplierStatusEnum.yaml
@@ -1,4 +1,5 @@
 title: Enum_SupplierStatus
+description: The current status of this message within the channel at the time this response was generated.
 type: string
 enum:
   - delivered

--- a/specification/schemas/enums/TypeMessage.yaml
+++ b/specification/schemas/enums/TypeMessage.yaml
@@ -1,5 +1,5 @@
+title: Type_Message
 type: string
 enum:
   - Message
-title: Type_Message
 example: Message

--- a/specification/schemas/enums/TypeMessageBatch.yaml
+++ b/specification/schemas/enums/TypeMessageBatch.yaml
@@ -1,5 +1,5 @@
+title: Type_MessageBatch
 type: string
 enum:
   - MessageBatch
-title: Type_MessageBatch
 example: MessageBatch

--- a/specification/schemas/enums/TypeNhsAppAccounts.yaml
+++ b/specification/schemas/enums/TypeNhsAppAccounts.yaml
@@ -1,5 +1,5 @@
+title: Type_NhsAppAccounts
 type: string
 enum:
   - NhsAppAccounts
-title: Type_NhsAppAccounts
 example: NhsAppAccounts

--- a/specification/schemas/requests/CreateMessage.yaml
+++ b/specification/schemas/requests/CreateMessage.yaml
@@ -5,7 +5,7 @@ properties:
     type: object
     properties:
       type:
-        $ref: ../enums/TypeMessage.yaml
+        $ref: ../enums/EnumMessage.yaml
       attributes:
         type: object
         required:

--- a/specification/schemas/requests/CreateMessageBatch.yaml
+++ b/specification/schemas/requests/CreateMessageBatch.yaml
@@ -5,7 +5,7 @@ properties:
     type: object
     properties:
       type:
-        $ref: ../enums/TypeMessageBatch.yaml
+        $ref: ../enums/EnumMessageBatch.yaml
       attributes:
         description: MessageBatch attributes
         type: object

--- a/specification/schemas/responses/MessageBatch.yaml
+++ b/specification/schemas/responses/MessageBatch.yaml
@@ -7,7 +7,7 @@ properties:
     additionalProperties: false
     properties:
       type:
-        $ref: ../enums/TypeMessageBatch.yaml
+        $ref: ../enums/EnumMessageBatch.yaml
       id:
         $ref: ../types/KSUID.yaml
         description: Identifier for this MessageBatch. You should store this identifier for later lookups.

--- a/specification/schemas/responses/MessageCreated.yaml
+++ b/specification/schemas/responses/MessageCreated.yaml
@@ -7,7 +7,7 @@ properties:
     additionalProperties: false
     properties:
       type:
-        $ref: ../enums/TypeMessage.yaml
+        $ref: ../enums/EnumMessage.yaml
       id:
         $ref: ../types/KSUID.yaml
         description: Identifier for this Message. You should store this identifier for later lookups.

--- a/specification/schemas/responses/MessageResponse.yaml
+++ b/specification/schemas/responses/MessageResponse.yaml
@@ -40,10 +40,9 @@ properties:
               additionalProperties: false
               properties:
                 type:
-                  description: This is the type of channel to be used.
                   $ref: ../enums/ChannelType.yaml
                 retryCount:
-                  description: Contains the amount of times that we have attempted to send this channel.
+                  description: Contains the amount of times that we have attempted to send this message to this channel.
                   type: integer
                   example: 1
                 channelStatus:

--- a/specification/schemas/responses/MessageResponse.yaml
+++ b/specification/schemas/responses/MessageResponse.yaml
@@ -7,7 +7,7 @@ properties:
     additionalProperties: false
     properties:
       type:
-        $ref: ../enums/TypeMessage.yaml
+        $ref: ../enums/EnumMessage.yaml
       id:
         $ref: ../types/KSUID.yaml
         description: Identifier for this Message.
@@ -23,7 +23,11 @@ properties:
               The current status of this message at the time this response was generated.
 
               For more information please check our documentation on message & channel statuses above.
+<<<<<<< HEAD
             $ref: ../enums/MessageStatusEnum.yaml
+=======
+            $ref: ../enums/EnumMessageStatus.yaml
+>>>>>>> 2bd5e73 (CCM-5995: Address review comments)
           messageStatusDescription:
             type: string
             description: If there is extra information associated with the status of this message, it is provided here.
@@ -42,9 +46,7 @@ properties:
                 type:
                   $ref: ../enums/ChannelType.yaml
                 retryCount:
-                  description: Contains the amount of times that we have attempted to send this message to this channel.
-                  type: integer
-                  example: 1
+                  $ref: ../../snippets/RetryCount.yaml
                 channelStatus:
                   description: |-
                     The current status of this channel at the time this response was generated.
@@ -175,7 +177,7 @@ properties:
                 additionalProperties: false
                 properties:
                   type:
-                    $ref: ../enums/TypeMessageBatch.yaml
+                    $ref: ../enums/EnumMessageBatch.yaml
                   id:
                     description: This is the unique identifier of the batch that contains this message.
                     $ref: ../types/KSUID.yaml

--- a/specification/schemas/responses/MessageResponse.yaml
+++ b/specification/schemas/responses/MessageResponse.yaml
@@ -23,11 +23,7 @@ properties:
               The current status of this message at the time this response was generated.
 
               For more information please check our documentation on message & channel statuses above.
-<<<<<<< HEAD
             $ref: ../enums/MessageStatusEnum.yaml
-=======
-            $ref: ../enums/EnumMessageStatus.yaml
->>>>>>> 2bd5e73 (CCM-5995: Address review comments)
           messageStatusDescription:
             type: string
             description: If there is extra information associated with the status of this message, it is provided here.

--- a/specification/schemas/types/KSUID.yaml
+++ b/specification/schemas/types/KSUID.yaml
@@ -3,4 +3,4 @@ title: Type_KSUID
 pattern: '^[a-zA-Z0-9]{27}$'
 minLength: 27
 maxLength: 27
-example: 0ujsszwN8NRY24YaXiTIE2VWDTS
+example: 2WL3qFTEFM0qMY8xjRbt1LIKCzM 

--- a/specification/schemas/types/KSUID.yaml
+++ b/specification/schemas/types/KSUID.yaml
@@ -1,5 +1,6 @@
 type: string
 title: Type_KSUID
+description: Identifier for the message.
 pattern: '^[a-zA-Z0-9]{27}$'
 minLength: 27
 maxLength: 27

--- a/specification/snippets/CorrelationParameter.yaml
+++ b/specification/snippets/CorrelationParameter.yaml
@@ -1,7 +1,7 @@
 name: X-Correlation-ID
 in: header
 description: |-
-  An optional ID which you can use to track transactions across multiple systems. It can take any value, but we recommend avoiding `.` characters.
+  An optional ID which you can use to track transactions across multiple systems. It can take any value, but we recommend avoiding `.` characters. If not provided in the request, NHS Notify will default to a system generated ID in its place.
   Mirrored back in a response header.
 schema:
   type: string

--- a/specification/snippets/CorrelationParameter.yaml
+++ b/specification/snippets/CorrelationParameter.yaml
@@ -2,7 +2,7 @@ name: X-Correlation-ID
 in: header
 description: |-
   An optional ID which you can use to track transactions across multiple systems. It can take any value, but we recommend avoiding `.` characters. If not provided in the request, NHS Notify will default to a system generated ID in its place.
-  Will be returned in a response header.
+  The ID will be returned in a response header.
 schema:
   type: string
   example: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA

--- a/specification/snippets/CorrelationParameter.yaml
+++ b/specification/snippets/CorrelationParameter.yaml
@@ -2,7 +2,7 @@ name: X-Correlation-ID
 in: header
 description: |-
   An optional ID which you can use to track transactions across multiple systems. It can take any value, but we recommend avoiding `.` characters. If not provided in the request, NHS Notify will default to a system generated ID in its place.
-  Mirrored back in a response header.
+  Will be returned in a response header.
 schema:
   type: string
   example: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA

--- a/specification/snippets/RetryCount.yaml
+++ b/specification/snippets/RetryCount.yaml
@@ -1,0 +1,3 @@
+type: integer
+description: Contains the number of times that we have attempted to send this message to this channel.
+example: 1


### PR DESCRIPTION
## Summary
Changes can be viewed in [Bloomreach](https://cms-training2.nhsd.io/cms/content/path/content/documents/corporate-website/developer/api-catalogue/nhs-notify/todr3/docs-todr3)

# CCM-5951 Get Message Status broken in API docs
![image](https://github.com/user-attachments/assets/f1d94405-f79f-47c4-b7cc-274e9e663801)

# CCM-5561 Update API documentation to specify supported character encoding
![image](https://github.com/user-attachments/assets/9d560bb6-c4d7-4165-a1aa-8b6e34718f1e)

![image](https://github.com/user-attachments/assets/557da960-0919-4d17-83b7-52bf9e400dc4)

# CCM-5937 Update API docs to reflect correlation ID functionality
The following is updated for every endpoint:
![image](https://github.com/user-attachments/assets/286bcdf2-6108-41e2-a612-5a77e96caa1a)

# CCM-5132 Add a disclaimer to our API doc to say we reserve the right to make additive / non-breaking changes to our endpoints
![image](https://github.com/user-attachments/assets/32b1dd06-84dd-4b84-bd34-6414b6b9a8f6)

# CCM-5995
1. Callback URL is different for Message Status vs. Channel Status
![image](https://github.com/user-attachments/assets/39e07877-1a81-40a4-aa5e-d7382d9d6658)
![image](https://github.com/user-attachments/assets/c5a6e881-5ac6-42d6-9e29-21a1927ccbea)
2. Separate ticket not in this PR (CCM-5693)
3. We're inconsistent in how we define enums. (Mixture with and without the "Enum_" prefix)
![image](https://github.com/user-attachments/assets/57504a69-d639-4766-b16e-d238750537e7)
4. Channel status page, supplier status in schema needs a description
![image](https://github.com/user-attachments/assets/738b0da7-84f6-4f90-8a55-b740ee23fe6c)

5. Message status page, no descriptions in schema
![image](https://github.com/user-attachments/assets/390759ff-4a11-4ff5-8fd1-93ce2c3cd71f)

6.  "NHS Notify can send a supplier status callback when:" - should refer to a channel status callback not a supplier status callback.
![image](https://github.com/user-attachments/assets/8ab1b428-d2c0-46f5-9713-868cd9bca84f)
7. "Contains the amount of times that we have attempted to send this channel." slight grammar tweak - should read "The number of times that we have attempted to send this message to this channel."
![image](https://github.com/user-attachments/assets/27ac41a1-e67e-47ef-b057-969b4dd28741)
8. On the Callbacks > Message Status page, the type of the messageStatus field is incorrectly listed as ChannelStatus - it should be Enum_MessageStatus
![image](https://github.com/user-attachments/assets/68a690a3-de1f-4373-a592-c8a4e59741a1)

9. On the Operations > Send a batch of messages,{{ Type_MessageBatch}} should be Enum_MessageBatch
![image](https://github.com/user-attachments/assets/6db14284-d231-455d-a452-a3fdfa926227)

10. On the Operations > Send a batch single message,{{ Type_Message}} should be Enum_Message
![image](https://github.com/user-attachments/assets/daf512e5-4e94-4a72-90eb-4b520c87fefa)

11. KSUID is missing a description on the schema tab
For both Message Status and Channel Status callback schemas
![image](https://github.com/user-attachments/assets/c51b72b6-04b0-4fef-98b2-7d41c82d48b7)

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [x] Tester approval
