### PR TITLE
CCM-5025: Contact details override error responses

### DIFF
--- a/proxies/shared/partials/Partial.Target.FaultRules.xml
+++ b/proxies/shared/partials/Partial.Target.FaultRules.xml
@@ -1,7 +1,7 @@
 <FaultRule name="combined_backend_fault_handler">
     [% include './partials/Partial.Component.SetResponseDefaults.xml' %]
     <Step>
-        <Name>ExtractVariables.NhsAppAccounts.Error</Name>
+        <Name>ExtractVariables.ErrorMessage</Name>
         <Condition>
             response.content ~~ "\{\u0022message\u0022:\u0022.*\u0022\}"
         </Condition>

--- a/proxies/shared/partials/Partial.Target.FaultRules.xml
+++ b/proxies/shared/partials/Partial.Target.FaultRules.xml
@@ -7,6 +7,24 @@
         </Condition>
     </Step>
     <Step>
+        <Name>ExtractVariables.ErrorDetails</Name>
+        <Condition>
+            response.content ~~ ".*\u0022errors\u0022:.*"
+        </Condition>
+    </Step>
+    <Step>
+        <Name>JavaScript.EnhanceErrorDetails</Name>
+        <Condition>
+            data.errors != null
+        </Condition>
+    </Step>
+    <Step>
+        <Name>RaiseFault.GenericErrorDetails</Name>
+        <Condition>
+            data.enhancedErrors != null
+        </Condition>
+    </Step>
+    <Step>
         <Name>RaiseFault.404NhsAppAccounts</Name>
         <Condition>
             (proxy.pathsuffix MatchesPath "/channels/nhsapp/accounts") and response.status.code = 404 and data.errorMessage != null

--- a/proxies/shared/policies/ExtractVariables.ErrorDetails.xml
+++ b/proxies/shared/policies/ExtractVariables.ErrorDetails.xml
@@ -1,0 +1,10 @@
+<ExtractVariables async="false" continueOnError="false" enabled="true" name="ExtractVariables.ErrorDetails">
+    <VariablePrefix>data</VariablePrefix>
+    <Source>error.content</Source>
+    <JSONPayload>
+        <Variable name="errors" type="string">
+            <JSONPath>$.errors</JSONPath>
+        </Variable>
+    </JSONPayload>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</ExtractVariables>

--- a/proxies/shared/policies/ExtractVariables.ErrorMessage.xml
+++ b/proxies/shared/policies/ExtractVariables.ErrorMessage.xml
@@ -1,4 +1,4 @@
-<ExtractVariables async="false" continueOnError="false" enabled="true" name="ExtractVariables.NhsAppAccounts.Error">
+<ExtractVariables async="false" continueOnError="false" enabled="true" name="ExtractVariables.ErrorMessage">
     <VariablePrefix>data</VariablePrefix>
     <Source>error.content</Source>
     <JSONPayload>

--- a/proxies/shared/policies/JavaScript.EnhanceErrorDetails.xml
+++ b/proxies/shared/policies/JavaScript.EnhanceErrorDetails.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<Javascript async="false" continueOnError="false" enabled="true" timeLimit="200" name="JavaScript.EnhanceErrorDetails">
+    <DisplayName>JavaScript.EnhanceErrorDetails</DisplayName>
+    <Properties/>
+    <ResourceURL>jsc://EnhanceErrorDetails.js</ResourceURL>
+</Javascript>

--- a/proxies/shared/policies/RaiseFault.GenericErrorDetails.xml
+++ b/proxies/shared/policies/RaiseFault.GenericErrorDetails.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+    Generic error response format. The errors are taken from data.enhancedErrors. Note the status code and reason phrase are not set but
+    derived from the target response.
+-->
+
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.GenericErrorDetails">
+    <DisplayName>RaiseFault.GenericErrorDetails</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <Payload variablePrefix="%" variableSuffix="#">
+            {
+                "errors" : %data.enhancedErrors#
+            }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/shared/resources/jsc/EnhanceErrorDetails.js
+++ b/proxies/shared/resources/jsc/EnhanceErrorDetails.js
@@ -1,0 +1,29 @@
+const errors = context.getVariable('data.errors');
+const messageId = context.getVariable('messageid');
+const statusCode = context.getVariable('response.status.code');
+const links = {
+    about : "{{ ERROR_ABOUT_LINK }}"
+};
+
+const enhancedErrors = [];
+
+JSON.parse(errors).forEach((error, index) => {
+    var code = 'CM_INVALID_VALUE';
+    if (error.title === 'Missing value') {
+        code = 'CM_MISSING_VALUE';
+    }
+
+    enhancedErrors.push({
+        id: messageId + '.' + index,
+        code: code,
+        links: links,
+        status: statusCode,
+        title: error.title,
+        detail: error.message,
+        source: {
+            pointer: error.field
+        }
+    });
+});
+
+context.setVariable("data.enhancedErrors", JSON.stringify(enhancedErrors));

--- a/sandbox/__test__/messages.spec.js
+++ b/sandbox/__test__/messages.spec.js
@@ -36,6 +36,41 @@ describe("/api/v1/messages", () => {
       .expect("Content-Type", /json/, done);
   });
 
+  it("returns a 400 for invalid email address", (done) => {
+    request(server)
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+              contactDetails: {
+                email: "invalidEmailAddress",
+              }
+            },
+            originator: {
+              odsCode: "X123"
+            },
+            personalisation: {},
+          },
+        },
+      })
+      .expect(400, {
+        message: "Invalid recipient contact details. Field 'email': Input failed format check",
+        errors: [
+          {
+            title: 'Invalid value',
+            field: '/data/attributes/recipient/contactDetails/email',
+            message: 'Input failed format check'
+          }
+        ]
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
   it("responds with a 201 when the request is correctly formatted", (done) => {
     request(server)
       .post("/api/v1/messages")

--- a/sandbox/handlers/config.js
+++ b/sandbox/handlers/config.js
@@ -19,6 +19,7 @@ validSendingGroupIds[trigger500SendingGroupId] = "Jc96S9y4AKjncXndUXiS7M7yIZ3jNt
 validSendingGroupIds[trigger425SendingGroupId] = "_oivtOz8fHRXhtZAyFxJmT2j_xpWzq9s";
 validSendingGroupIds[sendingGroupIdWithMissingNHSTemplates] = "DjAAu455M2TMq0VKEaD_1WZfwjkspJDL";
 validSendingGroupIds[globalFreeTextNhsAppSendingGroupId] = "odbGpMQvYRM7sp7jueU2lRHQiueKujVO";
+const invalidEmailAddress = "invalidEmailAddress";
 
 const duplicateTemplates = [
     {
@@ -58,4 +59,5 @@ export {
     globalFreeTextNhsAppSendingGroupId,
     noDefaultOdsClientAuth,
     noOdsChangeClientAuth,
+    invalidEmailAddress
 }

--- a/sandbox/handlers/messages.js
+++ b/sandbox/handlers/messages.js
@@ -1,5 +1,5 @@
 import KSUID from "ksuid";
-import { sendError, writeLog, hasValidGlobalTemplatePersonalisation } from "./utils.js";
+import { sendError, writeLog, hasValidGlobalTemplatePersonalisation, sendErrorWithDetails } from "./utils.js";
 import {
   sendingGroupIdWithMissingNHSTemplates,
   sendingGroupIdWithMissingTemplates,
@@ -9,7 +9,8 @@ import {
   validSendingGroupIds,
   globalFreeTextNhsAppSendingGroupId,
   noDefaultOdsClientAuth,
-  noOdsChangeClientAuth
+  noOdsChangeClientAuth,
+  invalidEmailAddress
 } from "./config.js"
 
 // Note: the docker container uses node:12 which does not support optional chaining
@@ -21,6 +22,16 @@ function getOriginatorOdsCode(req) {
     odsCode = undefined;
   }
   return odsCode;
+}
+
+function getEmailOverride(req) {
+  let email;
+  try {
+    email = req.body.data.attributes.recipient.contactDetails.email;
+  } catch {
+    email = undefined;
+  }
+  return email;
 }
 
 export async function messages(req, res, next) {
@@ -115,6 +126,20 @@ export async function messages(req, res, next) {
 
   if (routingPlanId === trigger500SendingGroupId) {
     sendError(res, 500, "Error writing request items to DynamoDB");
+    next();
+    return;
+  }
+
+  const emailOverride = getEmailOverride(req);
+  if (emailOverride === invalidEmailAddress) {
+    const errors = [
+      {
+        title: "Invalid value",
+        field: "/data/attributes/recipient/contactDetails/email",
+        message: "Input failed format check"
+      }
+    ];
+    sendErrorWithDetails(res, 400, "Invalid recipient contact details. Field 'email': Input failed format check", errors);
     next();
     return;
   }

--- a/sandbox/handlers/messages.js
+++ b/sandbox/handlers/messages.js
@@ -27,14 +27,6 @@ function getOriginatorOdsCode(req) {
 function getEmailOverride(req) {
  return req?.body?.data?.attributes?.recipient?.contactDetails?.email
 }
-  let email;
-  try {
-    email = req.body.data.attributes.recipient.contactDetails.email;
-  } catch {
-    email = undefined;
-  }
-  return email;
-}
 
 export async function messages(req, res, next) {
   if (req.headers.authorization === "banned") {

--- a/sandbox/handlers/messages.js
+++ b/sandbox/handlers/messages.js
@@ -25,6 +25,8 @@ function getOriginatorOdsCode(req) {
 }
 
 function getEmailOverride(req) {
+ return req?.body?.data?.attributes?.recipient?.contactDetails?.email
+}
   let email;
   try {
     email = req.body.data.attributes.recipient.contactDetails.email;

--- a/sandbox/handlers/utils.js
+++ b/sandbox/handlers/utils.js
@@ -43,6 +43,14 @@ export function sendError(res, code, message) {
   });
 }
 
+export function sendErrorWithDetails(res, code, message, errors) {
+  res.status(code);
+  res.json({
+    message,
+    errors
+  });
+}
+
 export function hasValidGlobalTemplatePersonalisation(personalisation) {
   if (!personalisation) {
     return false;


### PR DESCRIPTION
## Summary
This change is to handle an array of errors returned by the backend. Each error item contains:
- A title
- A pointer to the field causing the error
- A message

The implementation has been kept generic for now (no hardcoded status codes or reason phrases) in the hope that it can be reused in the future.

Note that automated tests are supposed to be added as part of [CCM-5328](https://nhsd-jira.digital.nhs.uk/browse/CCM-5328).

### Tested against de-sila7
#### Create Message
![image](https://github.com/user-attachments/assets/20c4a1f5-9670-4b99-9af9-b2d6ea69779f)

#### Create Batch
![image](https://github.com/user-attachments/assets/ac190d4b-f23d-49c0-9771-6485b1b08be2)



## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
