### PR TITLE
CCM-6020: generate new token if current will expire in 15s

### DIFF
--- a/tests/lib/authentication.py
+++ b/tests/lib/authentication.py
@@ -34,7 +34,7 @@ class AuthenticationCache():
         _, latest_token_expiry = self.tokens.get(env, (None, 0))
 
         # Generate new token if latest token will expire in 15 seconds
-        if env not in self.tokens or latest_token_expiry - 15 < int(time()):
+        if env not in self.tokens or latest_token_expiry < int(time()) + 15:
             pk_pem = None
             with open(private_key, "r") as f:
                 pk_pem = f.read()


### PR DESCRIPTION
## Summary

Changes auth logic in E2E to retrieve new token if current token is about to expire in 15 seconds.

Token has a validity of 3 minutes.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
