### PR TITLE
CCM-6595: Transform override contact details error response to match our API

### DIFF
--- a/docs/tests/sandbox/post_v1_message-batches/validation.md
+++ b/docs/tests/sandbox/post_v1_message-batches/validation.md
@@ -453,7 +453,7 @@ A valid sms contact detail must be structured in this format: { sms: value }
 
 ## Scenario: An API consumer submitting a request with an contact details when not allowed receives a 400 ‘Cannot set contact details’ response
 
-**Given** the API consumer provides an message body with contact details
+**Given** the API consumer provides a message body with contact details
 <br/>
 **When** the request is submitted
 <br/>

--- a/docs/tests/sandbox/post_v1_message-batches/validation.md
+++ b/docs/tests/sandbox/post_v1_message-batches/validation.md
@@ -451,6 +451,21 @@ A valid sms contact detail must be structured in this format: { sms: value }
 | 077009000021 | Used to ensure invalid phone number is not accepted |
 
 
+## Scenario: An API consumer submitting a request with an contact details when not allowed receives a 400 ‘Cannot set contact details’ response
+
+**Given** the API consumer provides an message body with contact details
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response returns a 400 Cannot set contact details error
+<br/>
+
+**Asserts**
+- Response returns a 400 ‘Cannot set contact details’ error
+- Response returns the expected error message body with references to the invalid attribute
+- Response returns the ‘X-Correlation-Id’ header if provided
+
+
 ## Scenario: An API consumer submitting a request with an invalid personalisation receives a 400 ‘Invalid Value’ response
 
 A valid personalisation must be structured in this format: { parameter: value }

--- a/docs/tests/sandbox/post_v1_messages/validation.md
+++ b/docs/tests/sandbox/post_v1_messages/validation.md
@@ -313,6 +313,21 @@ A valid sms contact detail must be structured in this format: { sms: value }
 | 077009000021 | Used to ensure invalid phone number is not accepted |
 
 
+## Scenario: An API consumer submitting a request with an contact details when not allowed receives a 400 ‘Cannot set contact details’ response
+
+**Given** the API consumer provides an message body with contact details
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response returns a 400 Cannot set contact details error
+<br/>
+
+**Asserts**
+- Response returns a 400 ‘Cannot set contact details’ error
+- Response returns the expected error message body with references to the invalid attribute
+- Response returns the ‘X-Correlation-Id’ header if provided
+
+
 ## Scenario: An API consumer submitting a request with an invalid personalisation receives a 400 ‘Invalid Value’ response
 
 A valid personalisation must be structured in this format: { parameter: value }

--- a/docs/tests/sandbox/post_v1_messages/validation.md
+++ b/docs/tests/sandbox/post_v1_messages/validation.md
@@ -315,7 +315,7 @@ A valid sms contact detail must be structured in this format: { sms: value }
 
 ## Scenario: An API consumer submitting a request with an contact details when not allowed receives a 400 ‘Cannot set contact details’ response
 
-**Given** the API consumer provides an message body with contact details
+**Given** the API consumer provides a message body with contact details
 <br/>
 **When** the request is submitted
 <br/>

--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -941,10 +941,11 @@ describe("/api/v1/send", () => {
         message: "Client is not allowed to provide alternative contact details",
         errors: [
           {
+            code: "CM_CANNOT_SET_CONTACT_DETAILS",
             title: 'Cannot set contact details',
             field: `/data/attributes/recipient/contactDetails`,
             message:
-              'Client is not allowed to provide alternative contact details',
+              'Client is not allowed to provide alternative contact details.',
           },
         ],
       })

--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -943,7 +943,7 @@ describe("/api/v1/send", () => {
           {
             code: "CM_CANNOT_SET_CONTACT_DETAILS",
             title: 'Cannot set contact details',
-            field: `/data/attributes/recipient/contactDetails`,
+            field: `/data/attributes/messages/0/recipient/contactDetails`,
             message:
               'Client is not allowed to provide alternative contact details.',
           },

--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -939,6 +939,14 @@ describe("/api/v1/send", () => {
       })
       .expect(400, {
         message: "Client is not allowed to provide alternative contact details",
+        errors: [
+          {
+            title: 'Cannot set contact details',
+            field: `/data/attributes/recipient/contactDetails`,
+            message:
+              'Client is not allowed to provide alternative contact details',
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });

--- a/sandbox/__test__/messages.spec.js
+++ b/sandbox/__test__/messages.spec.js
@@ -663,10 +663,11 @@ describe("/api/v1/messages", () => {
         message: "Client is not allowed to provide alternative contact details",
         errors: [
           {
+            code: "CM_CANNOT_SET_CONTACT_DETAILS",
             title: 'Cannot set contact details',
             field: `/data/attributes/recipient/contactDetails`,
             message:
-              'Client is not allowed to provide alternative contact details',
+              'Client is not allowed to provide alternative contact details.',
           },
         ],
       })

--- a/sandbox/__test__/messages.spec.js
+++ b/sandbox/__test__/messages.spec.js
@@ -661,6 +661,14 @@ describe("/api/v1/messages", () => {
       })
       .expect(400, {
         message: "Client is not allowed to provide alternative contact details",
+        errors: [
+          {
+            title: 'Cannot set contact details',
+            field: `/data/attributes/recipient/contactDetails`,
+            message:
+              'Client is not allowed to provide alternative contact details',
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -188,12 +188,13 @@ export function getAlternateContactDetailsError(
     return [
       400,
       "Client is not allowed to provide alternative contact details",
-      [{
-        code: "CM_CANNOT_SET_CONTACT_DETAILS",
-        title: "Cannot set contact details",
-        field: `${path}/recipient/contactDetails`,
-        message: "Client is not allowed to provide alternative contact details.",
-      },
+      [
+        {
+          code: "CM_CANNOT_SET_CONTACT_DETAILS",
+          title: "Cannot set contact details",
+          field: `${path}/recipient/contactDetails`,
+          message: "Client is not allowed to provide alternative contact details.",
+        },
       ]
     ];
   }

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -191,7 +191,7 @@ export function getAlternateContactDetailsError(
       [{
         code: "CM_CANNOT_SET_CONTACT_DETAILS",
         title: "Cannot set contact details",
-        field: `/data/attributes/recipient/contactDetails`,
+        field: `${path}/recipient/contactDetails`,
         message: "Client is not allowed to provide alternative contact details.",
       },
     ]

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -188,12 +188,13 @@ export function getAlternateContactDetailsError(
     return [
       400,
       "Client is not allowed to provide alternative contact details",
-      {
+      [{
         code: "CM_CANNOT_SET_CONTACT_DETAILS",
         title: "Cannot set contact details",
-        field: `Authorization`,
+        field: `/data/attributes/recipient/contactDetails`,
         message: "Client is not allowed to provide alternative contact details.",
       },
+    ]
     ];
   }
 

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -194,7 +194,7 @@ export function getAlternateContactDetailsError(
         field: `${path}/recipient/contactDetails`,
         message: "Client is not allowed to provide alternative contact details.",
       },
-    ]
+      ]
     ];
   }
 

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -188,6 +188,12 @@ export function getAlternateContactDetailsError(
     return [
       400,
       "Client is not allowed to provide alternative contact details",
+      {
+        code: "CM_CANNOT_SET_CONTACT_DETAILS",
+        title: "Cannot set contact details",
+        field: `Authorization`,
+        message: "Client is not allowed to provide alternative contact details.",
+      },
     ];
   }
 

--- a/tests/docs/partials/validation/test_not_permitted_to_use_contact_details.rst
+++ b/tests/docs/partials/validation/test_not_permitted_to_use_contact_details.rst
@@ -1,0 +1,15 @@
+Scenario: An API consumer submitting a request with an contact details when not allowed receives a 400 'Cannot set contact details' response
+======================================================================================================================
+
+
+| **Given** the API consumer provides an message body with contact details
+| **When** the request is submitted
+| **Then** the response returns a 400 Cannot set contact details error
+
+**Asserts**
+- Response returns a 400 'Cannot set contact details' error
+- Response returns the expected error message body with references to the invalid attribute
+- Response returns the 'X-Correlation-Id' header if provided
+
+
+

--- a/tests/docs/partials/validation/test_not_permitted_to_use_contact_details.rst
+++ b/tests/docs/partials/validation/test_not_permitted_to_use_contact_details.rst
@@ -10,6 +10,3 @@ Scenario: An API consumer submitting a request with an contact details when not 
 - Response returns a 400 'Cannot set contact details' error
 - Response returns the expected error message body with references to the invalid attribute
 - Response returns the 'X-Correlation-Id' header if provided
-
-
-

--- a/tests/docs/partials/validation/test_not_permitted_to_use_contact_details.rst
+++ b/tests/docs/partials/validation/test_not_permitted_to_use_contact_details.rst
@@ -2,7 +2,7 @@ Scenario: An API consumer submitting a request with an contact details when not 
 ======================================================================================================================
 
 
-| **Given** the API consumer provides an message body with contact details
+| **Given** the API consumer provides a message body with contact details
 | **When** the request is submitted
 | **Then** the response returns a 400 Cannot set contact details error
 

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -311,7 +311,7 @@ ERROR_NHS_APP_ACCOUNTS_TOO_MANY_REQUESTS = Error(
     "This endpoint is currently receiving a high volume of requests and is being rate limited."
 )
 
-ERROR_CANNOT_SET_CONTACT_DETAIL = Error(
+ERROR_CANNOT_SET_CONTACT_DETAILS = Error(
     "CM_CANNOT_SET_CONTACT_DETAILS",
     "400",
     "Cannot set contact details",

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -315,5 +315,5 @@ ERROR_CANNOT_SET_CONTACT_DETAILS = Error(
     "CM_CANNOT_SET_CONTACT_DETAILS",
     "400",
     "Cannot set contact details",
-    "Your account is not allowed to provide alternative contact details."
+    "Client is not allowed to provide alternative contact details."
 )

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -310,3 +310,10 @@ ERROR_NHS_APP_ACCOUNTS_TOO_MANY_REQUESTS = Error(
     "Too many requests",
     "This endpoint is currently receiving a high volume of requests and is being rate limited."
 )
+
+ERROR_CANNOT_SET_CONTACT_DETAIL = Error(
+    "CM_CANNOT_SET_CONTACT_DETAILS",
+    "400",
+    "Cannot set contact details",
+    "Your account is not allowed to provide alternative contact details."
+)

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -555,31 +555,14 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
     """
     .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
+    data = Generators.generate_valid_create_message_batch_body()
+    data["data"]["attributes"]["messages"][0]["recipient"]["contactDetails"]["sms"] = "07700900002"
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
         "Authorization": "notAllowedContactDetailOverride"
-    }, json={
-        "data": {
-            "type": "MessageBatch",
-            "attributes": {
-                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-                "messageBatchReference": str(uuid.uuid1()),
-                "messages": [
-                    {
-                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
-                        "recipient": {
-                            "nhsNumber": "9990548609",
-                            "dateOfBirth": "2023-01-01",
-                            "contactDetails": {
-                                "sms": "07700900002"
-                            }
-                        },
-                    }
-                ]
-            }
-        }
-    })
+    }, json=data
+    )
 
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -551,6 +551,50 @@ def test_null_personalisation(nhsd_apim_proxy_url, correlation_id, personalisati
 
 @pytest.mark.sandboxtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
+def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_id):
+    """
+    .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
+    """
+    resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
+        **headers,
+        "X-Correlation-Id": correlation_id,
+        "Authorization": "notAllowedContactDetailOverride"
+    }, json={
+        "data": {
+            "type": "MessageBatch",
+            "attributes": {
+                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+                "messageBatchReference": str(uuid.uuid1()),
+                "messages": [
+                    {
+                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "2023-01-01",
+                            "contactDetails": {
+                                "sms": "07700900002"
+                            }
+                        },
+                    }
+                ]
+            }
+        }
+    })
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        400,
+        Generators.generate_error(
+            constants.ERROR_CANNOT_SET_CONTACT_DETAIL,
+            source={
+                "pointer": "/data/attributes/messages/0/recipient/contactDetails"
+                }),
+        correlation_id
+    )
+
+
+@pytest.mark.sandboxtest
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
 def test_invalid_sms_contact_details(nhsd_apim_proxy_url, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -556,7 +556,7 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
     .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
     data = Generators.generate_valid_create_message_batch_body()
-    data["data"]["attributes"]["messages"][0]["recipient"]["contactDetails"]["sms"] = "07700900002"
+    data["data"]["attributes"]["messages"][0]["recipient"]["contactDetails"] = {"sms": "07700900002"}
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -553,7 +553,7 @@ def test_null_personalisation(nhsd_apim_proxy_url, correlation_id, personalisati
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
 def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_id):
     """
-    .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
+    .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -588,7 +588,8 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
             constants.ERROR_CANNOT_SET_CONTACT_DETAILS,
             source={
                 "pointer": "/data/attributes/messages/0/recipient/contactDetails"
-                }),
+                }
+                ),
         correlation_id
     )
 

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -585,7 +585,7 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
         resp,
         400,
         Generators.generate_error(
-            constants.ERROR_CANNOT_SET_CONTACT_DETAIL,
+            constants.ERROR_CANNOT_SET_CONTACT_DETAILS,
             source={
                 "pointer": "/data/attributes/messages/0/recipient/contactDetails"
                 }),

--- a/tests/sandbox/messages/create_messages/test_field_validation.py
+++ b/tests/sandbox/messages/create_messages/test_field_validation.py
@@ -330,6 +330,45 @@ def test_null_personalisation(nhsd_apim_proxy_url, correlation_id, personalisati
 
 @pytest.mark.sandboxtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
+def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_id):
+    """
+    .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
+    """
+    resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
+        **headers,
+        "X-Correlation-Id": correlation_id,
+        "Authorization": "notAllowedContactDetailOverride"
+    }, json={
+        "data": {
+            "type": "Message",
+            "attributes": {
+                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+                "messageReference": str(uuid.uuid1()),
+                "recipient": {
+                    "nhsNumber": "9990548609",
+                    "dateOfBirth": "2023-01-01",
+                    "contactDetails": {
+                        "sms": "07700900002"
+                    }
+                },
+            }
+        }
+    })
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        400,
+        Generators.generate_error(
+            constants.ERROR_CANNOT_SET_CONTACT_DETAIL,
+            source={
+                "pointer": "/data/attributes/recipient/contactDetails"
+                }),
+        correlation_id
+    )
+
+
+@pytest.mark.sandboxtest
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
 def test_invalid_sms_contact_details(nhsd_apim_proxy_url, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst

--- a/tests/sandbox/messages/create_messages/test_field_validation.py
+++ b/tests/sandbox/messages/create_messages/test_field_validation.py
@@ -334,26 +334,14 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
     """
     .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
+    data = Generators.generate_valid_create_message_body()
+    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "07700900002"}
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
         "Authorization": "notAllowedContactDetailOverride"
-    }, json={
-        "data": {
-            "type": "Message",
-            "attributes": {
-                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-                "messageReference": str(uuid.uuid1()),
-                "recipient": {
-                    "nhsNumber": "9990548609",
-                    "dateOfBirth": "2023-01-01",
-                    "contactDetails": {
-                        "sms": "07700900002"
-                    }
-                },
-            }
-        }
-    })
+    }, json=data
+    )
 
     Assertions.assert_error_with_optional_correlation_id(
         resp,

--- a/tests/sandbox/messages/create_messages/test_field_validation.py
+++ b/tests/sandbox/messages/create_messages/test_field_validation.py
@@ -359,7 +359,7 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
         resp,
         400,
         Generators.generate_error(
-            constants.ERROR_CANNOT_SET_CONTACT_DETAIL,
+            constants.ERROR_CANNOT_SET_CONTACT_DETAILS,
             source={
                 "pointer": "/data/attributes/recipient/contactDetails"
                 }),

--- a/tests/sandbox/messages/create_messages/test_field_validation.py
+++ b/tests/sandbox/messages/create_messages/test_field_validation.py
@@ -332,7 +332,7 @@ def test_null_personalisation(nhsd_apim_proxy_url, correlation_id, personalisati
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
 def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_id):
     """
-    .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
+    .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
         **headers,


### PR DESCRIPTION
## Summary

This PR is change the error response when a client tries to use the override contact details, when they do no have feature enable. 

Old response

```
{    
       "message": "Client is not allowed to provide alternative contact details"
} 
```

new response client response after Apigee: 

```
{
  "errors": [
    {
      "id": "rrt-8127824057098449875-a-geu2-9147-6573781-2.0",
      "code": "CM_CANNOT_SET_CONTACT_DETAILS",
      "links": {
        "about": "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
      },
      "status": "400",
      "title": "Cannot set contact details",
      "detail": "Client is not allowed to provide alternative contact details.",
      "source": {
        "pointer": "/data/attributes/recipient/contactDetails"
      }
    }
  ]
}
```


## Reviews Required
* [] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
