### PR TITLE
CCM-6618: Added details of 429 response code to callback docs

### DIFF
--- a/specification/callbacks/channel_status.yaml
+++ b/specification/callbacks/channel_status.yaml
@@ -41,3 +41,5 @@ responses:
         description: Unauthorized
     '403':
         description: Forbidden
+    '429':
+        $ref: ../responses/4xx/callbacks/429_TooManyRequests_Callbacks.yaml

--- a/specification/callbacks/message_status.yaml
+++ b/specification/callbacks/message_status.yaml
@@ -45,3 +45,5 @@ responses:
         description: Unauthorized
     '403':
         description: Forbidden
+    '429':
+        $ref: ../responses/4xx/callbacks/429_TooManyRequests_Callbacks.yaml

--- a/specification/responses/4xx/callbacks/429_TooManyRequests_Callbacks.yaml
+++ b/specification/responses/4xx/callbacks/429_TooManyRequests_Callbacks.yaml
@@ -1,0 +1,15 @@
+description: |+
+  If callbacks are being received at a faster rate than your client can process them, you can respond with a `429` status code to indicate that the callbacks should back-off and retry later. 
+  NHS Notify has a default retry policy which is exponential plus a randomised jitter. 
+  Your client may additionally provide the standard HTTP `Retry-After` response header to specify how long Notify should wait before retrying. NHS Notify will select the most conservative option between the standard retry policy and the `Retry-After` header. 
+  Send a negative value in the `Retry-After` header to stop retrying for that callback event.
+
+headers:
+  Retry-After:
+    schema:
+      type: integer
+      format: duration
+      minimum: 5
+      multipleOf: 1
+      example: 5
+    description: Time to wait between requests in seconds


### PR DESCRIPTION
## Summary
Added details of 429 response code to both Message and Channel status callbacks
![image](https://github.com/user-attachments/assets/4c5b0f11-2813-402b-9c8a-09f2cc447559)



## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
