### PR TITLE
CCM-6534 Introduce ref2

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -73,6 +73,22 @@ extends:
           - template: ./templates/run-tests.yml
             parameters:
               test_command: 'make internal-dev-test'
+      
+      - environment: ref
+        stage_name: ref2
+        service_name: "${{ variables.service_name }}-2"
+        short_service_name: "${{ variables.short_service_name }}-2"
+        service_base_path: "${{ variables.service_base_path }}-2"
+        depends_on:
+          - manual_approval_ref
+        jinja_templates:
+          ENVIRONMENT_TYPE: 'internal'
+          ERROR_ABOUT_LINK: ${{ variables.error_about_link }}
+          TARGET_SERVER_OVERRIDE: communications-manager-target-2
+        post_deploy:
+          - template: ./templates/run-tests.yml
+            parameters:
+              test_command: 'make internal-dev-test'
 
       - environment: manual-approval
         stage_name: manual_approval_internal_qa

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -3,29 +3,47 @@ PRODUCT_DISPLAY_NAME: Communications Manager
 DESCRIPTION: Use this API to send messages to citizens via email, SMS, the NHS App or letter.
 APIGEE_ENVIRONMENTS:
   - name: internal-dev
-    display_name: Internal Development
     has_mock_auth: true
-    app_ratelimit: '6000pm'
-    app_quota: '1200'
-    global_ratelimit: '18000pm'
-    global_quota: '6000'
+    variants:
+    - name: internal-dev
+      display_name: Internal Development
+      app_ratelimit: '6000pm'
+      app_quota: '1200'
+      global_ratelimit: '18000pm'
+      global_quota: '6000'
   - name: internal-qa
-    display_name: Internal QA
     has_mock_auth: true
+    variants:
+    - name: internal-qa
+      display_name: Internal QA
   - name: ref
-    display_name: Reference
     has_mock_auth: true
+    variants:
+    - name: ref
+      display_name: Reference
+    - name: 2-ref
+      display_name: Reference - 2
   - name: internal-dev-sandbox
-    display_name: Internal Development Sandbox
+    variants:
+    - name: internal-dev-sandbox
+      display_name: Internal Development Sandbox
   - name: internal-qa-sandbox
-    display_name: Internal QA Sandbox
+    variants:
+    - name: internal-qa-sandbox
+      display_name: Internal QA Sandbox
   - name: sandbox
-    display_name: Sandbox
+    variants:
+    - name: sandbox
+      display_name: Sandbox
   - name: int
-    display_name: Integration Testing
+    variants:
+    - name: int
+      display_name: Integration Testing
   - name: prod
-    display_name: Production
-    approval_type: manual
+    variants:
+    - name: prod
+      display_name: Production
+      approval_type: manual
 ---
 meta:
   api:
@@ -37,12 +55,13 @@ meta:
 apigee:
   environments:
 {% for ENV in APIGEE_ENVIRONMENTS %}
-{% set TITLE = PRODUCT_DISPLAY_NAME + ' (' + ENV.display_name + ' Environment)' %}
-{% set NAME = SERVICE_NAME + '-' + ENV.name %}
   - name: {{ ENV.name }}
     products:
+{% for VARIANT in ENV.variants %}
+{% set TITLE = PRODUCT_DISPLAY_NAME + ' (' + VARIANT.display_name + ' Environment)' %}
+{% set NAME = SERVICE_NAME + '-' + VARIANT.name %}
       - name: {{ NAME }}
-        approvalType: {{ ENV.approval_type | default('auto') }}
+        approvalType: {{ VARIANT.approval_type | default('auto') }}
         attributes:
           - name: access
             value: public
@@ -52,19 +71,19 @@ apigee:
                 quota:
                   enabled: true
                   interval: 1
-                  limit: {{ ENV.global_quota | default(6000)}}
+                  limit: {{ VARIANT.global_quota | default(6000)}}
                   timeunit: minute
                 spikeArrest:
                   enabled: true
-                  ratelimit: {{ ENV.global_ratelimit | default('18000pm') }}
+                  ratelimit: {{ VARIANT.global_ratelimit | default('18000pm') }}
               app:
                 quota:
                   enabled: true
                   interval: 1
-                  limit: {{ ENV.app_quota | default(1200)}}
+                  limit: {{ VARIANT.app_quota | default(1200)}}
                   timeunit: minute
                 spikeArrest:
-                  ratelimit: {{ ENV.app_ratelimit | default('6000pm') }}
+                  ratelimit: {{ VARIANT.app_ratelimit | default('6000pm') }}
                   enabled: true
         description: {{ DESCRIPTION }}
         displayName: {{ TITLE }}
@@ -78,15 +97,23 @@ apigee:
         scopes:
           - 'urn:nhsd:apim:app:level3:{{ SERVICE_NAME }}'
           - 'urn:nhsd:apim:user-nhs-cis2:aal3:{{ SERVICE_NAME }}'
+{% endfor %}
     specs:
+{% for VARIANT in ENV.variants %}
+{% set NAME = SERVICE_NAME + '-' + VARIANT.name %}
       - name: {{ NAME }}
         path: {{ SERVICE_NAME }}.json
+{% endfor %}
     api_catalog:
+{% for VARIANT in ENV.variants %}
+{% set NAME = SERVICE_NAME + '-' + VARIANT.name %}
+{% set TITLE = PRODUCT_DISPLAY_NAME + ' (' + VARIANT.display_name + ' Environment)' %}
       - edgeAPIProductName: {{ NAME }}
         anonAllowed: true
         description: {{ DESCRIPTION }}
         requireCallbackUrl: false
         title: {{ TITLE }}
-        visibility: {{ ENV.portal_visibility | default(true) }}
+        visibility: {{ VARIANT.portal_visibility | default(true) }}
         specId: {{ NAME }}
+{% endfor %}
 {% endfor %}

--- a/proxies/live/apiproxy/targets/target.xml
+++ b/proxies/live/apiproxy/targets/target.xml
@@ -19,7 +19,7 @@
             <Enabled>true</Enabled>
         </SSLInfo>
         <LoadBalancer>
-            <Server name="communications-manager-target" />
+            <Server name="{{ TARGET_SERVER_OVERRIDE | default('communications-manager-target') }}"/>
         </LoadBalancer>
         <Path>{requestpath}</Path>
         <Properties>


### PR DESCRIPTION
## Summary

Create a new proxy pointing a the ref2 backend. The base URL to access will be `https://ref.api.service.nhs.uk/comms-2`

### Test Evidence
![image](https://github.com/user-attachments/assets/16c5ed8d-3c5b-4cf6-ba6a-00bd6f5fcbbb)
![image](https://github.com/user-attachments/assets/2ff36d74-7e1f-483b-bb0f-cc5b2317cdd2)
![image](https://github.com/user-attachments/assets/888e5e4c-ef7f-4e48-8da8-f35497a00935)
![image](https://github.com/user-attachments/assets/b3e7524d-27ea-41f6-bcc3-bb65774c87de)

Deployed using this pipeline: https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId=247788&view=logs&j=78ebf54a-ef06-5d5d-de23-54348247b70e&t=bc6420b1-fc92-5c3c-6e37-ffa2864a4d70
Note that the failing tests are caused by the fact that Ref2 does not contain CCM-6415 which should be released as part of 4.27.0.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
