### PR TITLE
CCM-6415: Return message index for contact details APIM tests

### DIFF
--- a/docs/tests/development/post_v1_message-batches/validation.md
+++ b/docs/tests/development/post_v1_message-batches/validation.md
@@ -325,6 +325,27 @@ A valid contact detail must be structured in this format: { email: Value }
 | invalidEmailAddress | Used to ensure invalid email address is not accepted |
 
 
+## Scenario: An API consumer submitting a request with an invalid email receives a 400 ‘Invalid Value’ response
+
+A valid contact detail must be structured in this format: { email: Value }
+
+**Given** the API consumer provides an message body with an invalid email address
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response returns a 400 invalid value error
+<br/>
+
+**Asserts**
+- Response returns a 400 ‘Invalid Value’ error
+- Response returns the expected error message body with references to the invalid attribute
+- Response returns the ‘X-Correlation-Id’ header if provided
+
+| Value               | Description                                          |
+|---------------------|------------------------------------------------------|
+| invalidEmailAddress | Used to ensure invalid email address is not accepted |
+
+
 ## Scenario: An API consumer submitting a request with an invalid message batch reference receives a 400 ‘Invalid Value’ response
 
 The message batch reference must be in a UUID format, for more information on UUID, look [here](https://en.wikipedia.org/wiki/Universally_unique_identifier)
@@ -449,6 +470,27 @@ This test uses the ‘X-Correlation-Id’ header, when provided in a request it 
 |--------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | None                                 | Is tested to ensure that we do not send back a correlation identifier if one was not provided in the request. |
 | 76491414-d0cf-4655-ae20-a4d1368472f3 | Is tested to ensure that when a correlation identifier is sent, we respond with the same value.               |
+
+
+## Scenario: An API consumer submitting a request with an invalid sms receives a 400 ‘Invalid Value’ response
+
+A valid sms contact detail must be structured in this format: { sms: value }
+
+**Given** the API consumer provides an message body with an invalid sms
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response returns a 400 invalid value error
+<br/>
+
+**Asserts**
+- Response returns a 400 ‘Invalid Value’ error
+- Response returns the expected error message body with references to the invalid attribute
+- Response returns the ‘X-Correlation-Id’ header if provided
+
+|        Value | Description                                         |
+|--------------|-----------------------------------------------------|
+| 077009000021 | Used to ensure invalid phone number is not accepted |
 
 
 ## Scenario: An API consumer submitting a request with an invalid sms receives a 400 ‘Invalid Value’ response

--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -850,7 +850,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'sms': Input failed format check",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/sms",
+            field: "/data/attributes/messages/0/recipient/contactDetails/sms",
             message: "Input failed format check",
             title: "Invalid value"
           }
@@ -891,7 +891,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'sms': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/sms",
+            field: "/data/attributes/messages/0/recipient/contactDetails/sms",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -960,7 +960,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'email': Input failed format check",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/email",
+            field: "/data/attributes/messages/0/recipient/contactDetails/email",
             message: "Input failed format check",
             title: "Invalid value"
           }
@@ -1000,7 +1000,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'email': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/email",
+            field: "/data/attributes/messages/0/recipient/contactDetails/email",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -1071,7 +1071,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'address': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -1109,7 +1109,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'address': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -1150,7 +1150,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'lines': 'lines' is missing",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "`lines` is missing",
             title: "Missing value"
           }
@@ -1191,7 +1191,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'lines': Too few address lines were provided",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Too few address lines were provided",
             title: "Missing value"
           }
@@ -1232,7 +1232,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'lines': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -1273,7 +1273,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'lines': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -1313,7 +1313,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'postcode': 'postcode' is missing",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "`postcode` is missing",
             title: "Missing value"
           }
@@ -1354,7 +1354,7 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'postcode': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address/postcode",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address/postcode",
             message: "Invalid",
             title: "Invalid value"
           }
@@ -1395,12 +1395,12 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'email': Input failed format check. Field 'lines': Too few address lines were provided",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/email",
+            field: "/data/attributes/messages/0/recipient/contactDetails/email",
             message: "Input failed format check",
             title: "Invalid value"
           },
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address",
+            field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Too few address lines were provided",
             title: "Missing value"
           },

--- a/sandbox/handlers/batch_send.js
+++ b/sandbox/handlers/batch_send.js
@@ -71,8 +71,9 @@ export async function batchSend(req, res, next) {
   }
 
   const alternateContactDetails = messages.map((message) => message.recipient?.contactDetails)
+  let messageIndex = 0;
   for (const contactDetail of alternateContactDetails) {
-    const alternateContactDetailsError = getAlternateContactDetailsError(contactDetail, req.headers.authorization, '/data/attributes/messages')
+    const alternateContactDetailsError = getAlternateContactDetailsError(contactDetail, req.headers.authorization, `/data/attributes/messages/${messageIndex}`)
     if (alternateContactDetailsError !== null) {
       const [errorCode, errorMessage, errors] = alternateContactDetailsError
       sendError(
@@ -84,6 +85,7 @@ export async function batchSend(req, res, next) {
       next()
       return;
     }
+    messageIndex += 1; 
   }
 
   writeLog(res, "warn", {

--- a/tests/development/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/development/message_batches/create_message_batches/test_field_validation.py
@@ -576,6 +576,58 @@ def test_invalid_sms_contact_details(nhsd_apim_proxy_url, bearer_token_internal_
 
 @pytest.mark.devtest
 @pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
+def test_invalid_sms_contact_details_second_message(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
+    """
+    .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
+    """
+    resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
+        "Authorization": bearer_token_internal_dev.value,
+        **headers,
+        "X-Correlation-Id": correlation_id
+    }, json={
+        "data": {
+            "type": "MessageBatch",
+            "attributes": {
+                "routingPlanId": "0e38317f-1670-480a-9aa9-b711fb136610",
+                "messageBatchReference": str(uuid.uuid1()),
+                "messages": [
+                    {
+                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "2023-01-01"
+                        },
+                        "personalisation": {}
+                    },
+                    {
+                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1c",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "2023-01-01",
+                            "contactDetails": {
+                                "sms": "077009000021"
+                            }
+                        },
+                        "personalisation": {}
+                    }
+                ]
+            }
+        }
+    })
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        400,
+        Generators.generate_invalid_value_error_custom_detail(
+            "/data/attributes/messages/1/recipient/contactDetails/sms",
+            "Input failed format check"
+        ),
+        correlation_id
+    )
+
+
+@pytest.mark.devtest
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
 def test_invalid_email_contact_details(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
     """
     .. include:: ../../partials/validation/test_invalid_contact_details_email.rst
@@ -612,6 +664,66 @@ def test_invalid_email_contact_details(nhsd_apim_proxy_url, bearer_token_interna
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/messages/0/recipient/contactDetails/email",
+            "Input failed format check"
+        ),
+        correlation_id
+    )
+
+
+@pytest.mark.devtest
+@pytest.mark.parametrize("correlation_id", constants.CORRELATION_ID)
+def test_invalid_email_contact_details_third_message(nhsd_apim_proxy_url, bearer_token_internal_dev, correlation_id):
+    """
+    .. include:: ../../partials/validation/test_invalid_contact_details_email.rst
+    """
+    resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
+        "Authorization": bearer_token_internal_dev.value,
+        **headers,
+        "X-Correlation-Id": correlation_id
+    }, json={
+        "data": {
+            "type": "MessageBatch",
+            "attributes": {
+                "routingPlanId": "0e38317f-1670-480a-9aa9-b711fb136610",
+                "messageBatchReference": str(uuid.uuid1()),
+                "messages": [
+                    {
+                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1b",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "2023-01-01"
+                        },
+                        "personalisation": {}
+                    },
+                    {
+                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1c",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "2023-01-01"
+                        },
+                        "personalisation": {}
+                    },
+                    {
+                        "messageReference": "72f2fa29-1570-47b7-9a67-63dc4b28fc1d",
+                        "recipient": {
+                            "nhsNumber": "9990548609",
+                            "dateOfBirth": "2023-01-01",
+                            "contactDetails": {
+                                "email": "invalidEmailAddress"
+                            }
+                        },
+                        "personalisation": {}
+                    }
+                ]
+            }
+        }
+    })
+
+    Assertions.assert_error_with_optional_correlation_id(
+        resp,
+        400,
+        Generators.generate_invalid_value_error_custom_detail(
+            "/data/attributes/messages/2/recipient/contactDetails/email",
             "Input failed format check"
         ),
         correlation_id

--- a/tests/development/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/development/message_batches/create_message_batches/test_field_validation.py
@@ -567,7 +567,7 @@ def test_invalid_sms_contact_details(nhsd_apim_proxy_url, bearer_token_internal_
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/sms",
+            "/data/attributes/messages/0/recipient/contactDetails/sms",
             "Input failed format check"
         ),
         correlation_id
@@ -611,7 +611,7 @@ def test_invalid_email_contact_details(nhsd_apim_proxy_url, bearer_token_interna
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/email",
+            "/data/attributes/messages/0/recipient/contactDetails/email",
             "Input failed format check"
         ),
         correlation_id
@@ -667,7 +667,7 @@ def test_invalid_address_contact_details_too_few_lines(nhsd_apim_proxy_url, bear
         resp,
         400,
         Generators.generate_error(error, source={
-            "pointer": "/data/attributes/messages/recipient/contactDetails/address"
+            "pointer": "/data/attributes/messages/0/recipient/contactDetails/address"
         }),
         correlation_id
     )
@@ -720,7 +720,7 @@ def test_invalid_address_contact_details_too_many_lines(nhsd_apim_proxy_url, bea
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/address",
+            "/data/attributes/messages/0/recipient/contactDetails/address",
             "Invalid"
         ),
         correlation_id
@@ -773,7 +773,7 @@ def test_invalid_address_contact_details_postcode(nhsd_apim_proxy_url, bearer_to
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/address",
+            "/data/attributes/messages/0/recipient/contactDetails/address",
             "Postcode input failed format check"
         ),
         correlation_id

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -584,7 +584,7 @@ def test_invalid_sms_contact_details(nhsd_apim_proxy_url, correlation_id):
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/sms",
+            "/data/attributes/messages/0/recipient/contactDetails/sms",
             "Input failed format check"
         ),
         correlation_id
@@ -626,7 +626,7 @@ def test_invalid_email_contact_details(nhsd_apim_proxy_url, correlation_id):
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/email",
+            "/data/attributes/messages/0/recipient/contactDetails/email",
             "Input failed format check"
         ),
         correlation_id
@@ -680,7 +680,7 @@ def test_invalid_address_contact_details_too_few_lines(nhsd_apim_proxy_url, corr
         resp,
         400,
         Generators.generate_error(error, source={
-            "pointer": "/data/attributes/messages/recipient/contactDetails/address"
+            "pointer": "/data/attributes/messages/0/recipient/contactDetails/address"
         }),
         correlation_id
     )
@@ -731,7 +731,7 @@ def test_invalid_address_contact_details_too_many_lines(nhsd_apim_proxy_url, cor
         resp,
         400,
         Generators.generate_invalid_value_error_custom_detail(
-            "/data/attributes/messages/recipient/contactDetails/address",
+            "/data/attributes/messages/0/recipient/contactDetails/address",
             "Invalid"
         ),
         correlation_id


### PR DESCRIPTION
## Summary
Front-end update to accommodate the backend now returning a messageIndex for batch contact details validation errors.

Note that https://github.com/NHSDigital/comms-mgr/pull/184 needs to be merged and deployed to internal-dev first.

Tests run against de-sila7:
![image](https://github.com/user-attachments/assets/fddd57fb-c215-4a55-be31-e4c230127cc0)



## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
