### PR TITLE
CCM-6362: add default timeout for NHS app test function

### DIFF
--- a/tests/lib/helper.py
+++ b/tests/lib/helper.py
@@ -68,6 +68,7 @@ class Helper():
             install(playwright.chromium)
             browser = playwright.chromium.launch()
             page = browser.new_page()
+            page.set_default_timeout(15000)
 
             page.goto("https://www-onboardingaos.nhsapp.service.nhs.uk/login")
 
@@ -78,11 +79,11 @@ class Helper():
             page.get_by_label("Email address", exact=True).fill(email)
             page.get_by_role("button", name="Continue").click()
 
-            expect(page.get_by_role("heading", name="Enter your password")).to_be_visible(timeout=10000)
+            expect(page.get_by_role("heading", name="Enter your password")).to_be_visible()
             page.get_by_label("Password", exact=True).fill(password)
             page.get_by_role("button", name="Continue").click()
 
-            expect(page.get_by_role("heading", name="Enter the security code")).to_be_visible(timeout=10000)
+            expect(page.get_by_role("heading", name="Enter the security code")).to_be_visible()
             page.get_by_label("Security code", exact=True).fill(otp)
             page.get_by_role("button", name="Continue").click()
 


### PR DESCRIPTION
## Summary
Adds a default timeout for all browser actions in the NHS app message check test function. 


## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [x] Tester approval
