### PR TITLE
CCM-6453: add freetext sms and email to sandbox

### DIFF
--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -1,8 +1,7 @@
-import request from "supertest"
+import request from "supertest";
 import { assert } from "chai";
-import * as uuid from 'uuid';
-import { setup } from './helpers.js'
-
+import * as uuid from "uuid";
+import { setup } from "./helpers.js";
 
 describe("/api/v1/send", () => {
   let env;
@@ -466,7 +465,7 @@ describe("/api/v1/send", () => {
     const correlationId = uuid.v4();
     request(server)
       .post("/api/v1/send")
-      .set('X-Correlation-Id', correlationId)
+      .set("X-Correlation-Id", correlationId)
       .send({
         data: {
           type: "MessageBatch",
@@ -580,7 +579,7 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Expect single personalisation field of 'body'",
+        message: "Some personalisation fields are missing: body",
       })
       .expect("Content-Type", /json/, done);
   });
@@ -620,12 +619,12 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Expect single personalisation field of 'body'",
+        message: "Some personalisation fields are missing: body",
       })
       .expect("Content-Type", /json/, done);
   });
 
-  it("responds with a 400 for redundant personalisation for global NHS app routing plan", (done) => {
+  it("responds with a 200 for redundant personalisation for global NHS app routing plan", (done) => {
     request(server)
       .post("/api/v1/send")
       .send({
@@ -660,9 +659,166 @@ describe("/api/v1/send", () => {
           },
         },
       })
-      .expect(400, {
-        message: "Expect single personalisation field of 'body'",
+      .expect(200)
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 400 for missing personalisation fields for global email routing plan", (done) => {
+    request(server)
+      .post("/api/v1/send")
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000002",
+            messageBatchReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                },
+                originator: {
+                  odsCode: "X123",
+                },
+                personalisation: {},
+              },
+            ],
+          },
+        },
       })
+      .expect(400, {
+        message:
+          "Some personalisation fields are missing: email_subject,email_body",
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 400 for missing personalisation field for global email routing plan", (done) => {
+    request(server)
+      .post("/api/v1/send")
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000002",
+            messageBatchReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                },
+                originator: {
+                  odsCode: "X123",
+                },
+                personalisation: {
+                  email_subject: "test",
+                },
+              },
+            ],
+          },
+        },
+      })
+      .expect(400, {
+        message: "Some personalisation fields are missing: email_body",
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 200 when required fields provided for global email routing plan", (done) => {
+    request(server)
+      .post("/api/v1/send")
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000002",
+            messageBatchReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                },
+                originator: {
+                  odsCode: "X123",
+                },
+                personalisation: {
+                  email_subject: "test",
+                  email_body: "test",
+                },
+              },
+            ],
+          },
+        },
+      })
+      .expect(200)
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 400 for missing personalisation for global sms routing plan", (done) => {
+    request(server)
+      .post("/api/v1/send")
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000003",
+            messageBatchReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                },
+                originator: {
+                  odsCode: "X123",
+                },
+                personalisation: {},
+              },
+            ],
+          },
+        },
+      })
+      .expect(400, {
+        message: "Some personalisation fields are missing: sms_body",
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 200 when required fields provided for global sms routing plan", (done) => {
+    request(server)
+      .post("/api/v1/send")
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000003",
+            messageBatchReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                },
+                originator: {
+                  odsCode: "X123",
+                },
+                personalisation: {
+                  sms_body: "test",
+                },
+              },
+            ],
+          },
+        },
+      })
+      .expect(200)
       .expect("Content-Type", /json/, done);
   });
 
@@ -683,8 +839,8 @@ describe("/api/v1/send", () => {
               {
                 messageReference: "2",
                 originator: {
-                  odsCode: "X26"
-                }
+                  odsCode: "X26",
+                },
               },
             ],
           },
@@ -713,15 +869,16 @@ describe("/api/v1/send", () => {
               {
                 messageReference: "2",
                 originator: {
-                  odsCode: "X26"
-                }
+                  odsCode: "X26",
+                },
               },
             ],
           },
         },
       })
       .expect(400, {
-        message: "odsCode was provided but ODS code override is not enabled for the client",
+        message:
+          "odsCode was provided but ODS code override is not enabled for the client",
       })
       .expect("Content-Type", /json/, done);
   });
@@ -730,29 +887,27 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      email: 'hello'
-                    },
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    email: "hello",
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        }
-      )
+        },
+      })
       .expect(200)
       .expect("Content-Type", /json/, done);
   });
@@ -761,29 +916,27 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "notAllowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      sms: 'hello'
-                    },
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    sms: "hello",
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        }
-      )
+        },
+      })
       .expect(400, {
         message: "Client is not allowed to provide alternative contact details",
       })
@@ -794,28 +947,27 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      sms: 'hello'
-                    },
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    sms: "hello",
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(200)
       .expect("Content-Type", /json/, done);
   });
@@ -824,37 +976,37 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      sms: '07700900002'
-                    },
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    sms: "07700900002",
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'sms': Input failed format check",
+        message:
+          "Invalid recipient contact details. Field 'sms': Input failed format check",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/sms",
             message: "Input failed format check",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -863,39 +1015,38 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      sms: {
-                        hello: 1
-                      }
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    sms: {
+                      hello: 1,
                     },
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(400, {
         message: "Invalid recipient contact details. Field 'sms': Invalid",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/sms",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -904,28 +1055,27 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      email: 'hello'
-                    },
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    email: "hello",
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(200)
       .expect("Content-Type", /json/, done);
   });
@@ -934,37 +1084,37 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      email: 'invalidEmailAddress'
-                    },
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    email: "invalidEmailAddress",
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'email': Input failed format check",
+        message:
+          "Invalid recipient contact details. Field 'email': Input failed format check",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/email",
             message: "Input failed format check",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -987,8 +1137,8 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     email: {
-                      hello: 1
-                    }
+                      hello: 1,
+                    },
                   },
                 },
               },
@@ -1002,9 +1152,9 @@ describe("/api/v1/send", () => {
           {
             field: "/data/attributes/messages/recipient/contactDetails/email",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1013,31 +1163,30 @@ describe("/api/v1/send", () => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      address: {
-                        lines: ['1', '2'],
-                        postcode: 'hello'
-                      }
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    address: {
+                      lines: ["1", "2"],
+                      postcode: "hello",
                     },
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(200)
       .expect("Content-Type", /json/, done);
   });
@@ -1059,7 +1208,7 @@ describe("/api/v1/send", () => {
                   nhsNumber: "1",
                   dateOfBirth: "1",
                   contactDetails: {
-                    address: 'hello'
+                    address: "hello",
                   },
                 },
               },
@@ -1073,9 +1222,9 @@ describe("/api/v1/send", () => {
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1097,7 +1246,7 @@ describe("/api/v1/send", () => {
                   nhsNumber: "1",
                   dateOfBirth: "1",
                   contactDetails: {
-                    address: []
+                    address: [],
                   },
                 },
               },
@@ -1111,9 +1260,9 @@ describe("/api/v1/send", () => {
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1136,9 +1285,9 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: 'test',
-                      postcode: 'test'
-                    }
+                      lines: "test",
+                      postcode: "test",
+                    },
                   },
                 },
               },
@@ -1147,14 +1296,15 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'lines': 'lines' is missing",
+        message:
+          "Invalid recipient contact details. Field 'lines': 'lines' is missing",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "`lines` is missing",
-            title: "Missing value"
-          }
-        ]
+            title: "Missing value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1177,9 +1327,9 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: ['1'],
-                      postcode: 'hello'
-                    }
+                      lines: ["1"],
+                      postcode: "hello",
+                    },
                   },
                 },
               },
@@ -1188,14 +1338,15 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'lines': Too few address lines were provided",
+        message:
+          "Invalid recipient contact details. Field 'lines': Too few address lines were provided",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Missing value"
-          }
-        ]
+            title: "Missing value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1218,9 +1369,9 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: ['1', '2', '3', '4', '5', '6'],
-                      postcode: 'hello'
-                    }
+                      lines: ["1", "2", "3", "4", "5", "6"],
+                      postcode: "hello",
+                    },
                   },
                 },
               },
@@ -1234,9 +1385,9 @@ describe("/api/v1/send", () => {
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1259,9 +1410,9 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: ['1', '2', 3, '4', '5'],
-                      postcode: 'hello'
-                    }
+                      lines: ["1", "2", 3, "4", "5"],
+                      postcode: "hello",
+                    },
                   },
                 },
               },
@@ -1275,9 +1426,9 @@ describe("/api/v1/send", () => {
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1300,8 +1451,8 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: ['1', '2'],
-                    }
+                      lines: ["1", "2"],
+                    },
                   },
                 },
               },
@@ -1310,14 +1461,15 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'postcode': 'postcode' is missing",
+        message:
+          "Invalid recipient contact details. Field 'postcode': 'postcode' is missing",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "`postcode` is missing",
-            title: "Missing value"
-          }
-        ]
+            title: "Missing value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1340,9 +1492,9 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: ['1', '2'],
-                      postcode: []
-                    }
+                      lines: ["1", "2"],
+                      postcode: [],
+                    },
                   },
                 },
               },
@@ -1354,15 +1506,16 @@ describe("/api/v1/send", () => {
         message: "Invalid recipient contact details. Field 'postcode': Invalid",
         errors: [
           {
-            field: "/data/attributes/messages/recipient/contactDetails/address/postcode",
+            field:
+              "/data/attributes/messages/recipient/contactDetails/address/postcode",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
-  it('returns a 400 and multiple errors when there are multiple issues in contact details provided', (done) => {
+  it("returns a 400 and multiple errors when there are multiple issues in contact details provided", (done) => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
@@ -1380,10 +1533,10 @@ describe("/api/v1/send", () => {
                   dateOfBirth: "1",
                   contactDetails: {
                     address: {
-                      lines: ['1'],
-                      postcode: []
+                      lines: ["1"],
+                      postcode: [],
                     },
-                    email: 'invalidEmailAddress'
+                    email: "invalidEmailAddress",
                   },
                 },
               },
@@ -1392,54 +1545,54 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'email': Input failed format check. Field 'lines': Too few address lines were provided",
+        message:
+          "Invalid recipient contact details. Field 'email': Input failed format check. Field 'lines': Too few address lines were provided",
         errors: [
           {
             field: "/data/attributes/messages/recipient/contactDetails/email",
             message: "Input failed format check",
-            title: "Invalid value"
+            title: "Invalid value",
           },
           {
             field: "/data/attributes/messages/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Missing value"
+            title: "Missing value",
           },
-        ]
+        ],
       })
       .expect("Content-Type", /json/, done);
-  })
+  });
 
   it("returns a 200 when all alternate contact details are provided", (done) => {
     request(server)
       .post("/api/v1/send")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "MessageBatch",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messages: [
-                {
-                  messageReference: "1",
-                  recipient: {
-                    nhsNumber: "1",
-                    dateOfBirth: "1",
-                    contactDetails: {
-                      email: 'hello',
-                      sms: 'hello',
-                      address: {
-                        lines: ['1', '2'],
-                        postcode: 'hello'
-                      }
+      .send({
+        data: {
+          type: "MessageBatch",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messages: [
+              {
+                messageReference: "1",
+                recipient: {
+                  nhsNumber: "1",
+                  dateOfBirth: "1",
+                  contactDetails: {
+                    email: "hello",
+                    sms: "hello",
+                    address: {
+                      lines: ["1", "2"],
+                      postcode: "hello",
                     },
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
-        })
+        },
+      })
       .expect(200)
       .expect("Content-Type", /json/, done);
   });

--- a/sandbox/__test__/messages.spec.js
+++ b/sandbox/__test__/messages.spec.js
@@ -1,7 +1,7 @@
-import request from "supertest"
+import request from "supertest";
 import { assert } from "chai";
-import * as uuid from 'uuid';
-import { setup } from './helpers.js'
+import * as uuid from "uuid";
+import { setup } from "./helpers.js";
 
 describe("/api/v1/messages", () => {
   let env;
@@ -86,29 +86,29 @@ describe("/api/v1/messages", () => {
       .expect("Content-Type", /json/, done);
   });
 
-  it("returns a 400 when the routingPlanId is null", (done) => { 
+  it("returns a 400 when the routingPlanId is null", (done) => {
     request(server)
-    .post("/api/v1/messages")
-    .send({
-      data: {
-        type: "Message",
-        attributes: {
-          routingPlanId: null,
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: null,
+          },
         },
-      },
-    })
-    .expect(400, {
-      message: "Missing routingPlanId",
-    })
-    .expect("Content-Type", /json/, done);
-  })
+      })
+      .expect(400, {
+        message: "Missing routingPlanId",
+      })
+      .expect("Content-Type", /json/, done);
+  });
 
   it("responds with a 201 when the request is correctly formatted", (done) => {
     request(server)
       .post("/api/v1/messages")
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -117,7 +117,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
@@ -149,7 +149,7 @@ describe("/api/v1/messages", () => {
       .post("/api/v1/messages")
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -158,13 +158,13 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
         },
       })
-      .set('X-Correlation-Id', correlationId)
+      .set("X-Correlation-Id", correlationId)
       .expect(201)
       .expect("X-Correlation-Id", correlationId, done);
   });
@@ -174,7 +174,7 @@ describe("/api/v1/messages", () => {
       .post("/api/v1/messages")
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "00000000-0000-0000-0000-000000000001",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -183,7 +183,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {
               body: "Free text message",
@@ -216,7 +216,7 @@ describe("/api/v1/messages", () => {
       .post("/api/v1/messages")
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "00000000-0000-0000-0000-000000000001",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -225,13 +225,13 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
           },
         },
       })
       .expect(400, {
-        message: "Expect single personalisation field of 'body'",
+        message: "Some personalisation fields are missing: body",
       })
       .expect("Content-Type", /json/, done);
   });
@@ -241,7 +241,7 @@ describe("/api/v1/messages", () => {
       .post("/api/v1/messages")
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "00000000-0000-0000-0000-000000000001",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -250,7 +250,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
           },
           personalisation: {
@@ -259,7 +259,7 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Expect single personalisation field of 'body'",
+        message: "Some personalisation fields are missing: body",
       })
       .expect("Content-Type", /json/, done);
   });
@@ -269,7 +269,7 @@ describe("/api/v1/messages", () => {
       .post("/api/v1/messages")
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "00000000-0000-0000-0000-000000000001",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -278,7 +278,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
           },
           personalisation: {
@@ -288,8 +288,142 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Expect single personalisation field of 'body'",
+        message: "Some personalisation fields are missing: body",
       })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 400 for missing personalisation fields for global email routing plan", (done) => {
+    request(server)
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000002",
+            messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+            },
+            originator: {
+              odsCode: "X123",
+            },
+            personalisation: {},
+          },
+        },
+      })
+      .expect(400, {
+        message:
+          "Some personalisation fields are missing: email_subject,email_body",
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 400 for missing personalisation field for global email routing plan", (done) => {
+    request(server)
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000002",
+            messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+            },
+            originator: {
+              odsCode: "X123",
+            },
+            personalisation: {
+              email_subject: "test",
+            },
+          },
+        },
+      })
+      .expect(400, {
+        message: "Some personalisation fields are missing: email_body",
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 200 when required fields provided for global email routing plan", (done) => {
+    request(server)
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000002",
+            messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+            },
+            originator: {
+              odsCode: "X123",
+            },
+            personalisation: {
+              email_subject: "test",
+              email_body: "test",
+            },
+          },
+        },
+      })
+      .expect(201)
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 400 for missing personalisation for global sms routing plan", (done) => {
+    request(server)
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000003",
+            messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+            },
+            originator: {
+              odsCode: "X123",
+            },
+            personalisation: {},
+          },
+        },
+      })
+      .expect(400, {
+        message: "Some personalisation fields are missing: sms_body",
+      })
+      .expect("Content-Type", /json/, done);
+  });
+
+  it("responds with a 200 when required fields provided for global sms routing plan", (done) => {
+    request(server)
+      .post("/api/v1/messages")
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: "00000000-0000-0000-0000-000000000003",
+            messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+            },
+            originator: {
+              odsCode: "X123",
+            },
+            personalisation: {
+              sms_body: "test",
+            },
+          },
+        },
+      })
+      .expect(201)
       .expect("Content-Type", /json/, done);
   });
 
@@ -307,7 +441,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "2000-01-01",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
@@ -334,7 +468,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "2000-01-01",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
@@ -361,7 +495,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "2000-01-01",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
@@ -388,7 +522,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "2000-01-01",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
@@ -415,7 +549,7 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "2000-01-01",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
@@ -433,7 +567,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "noDefaultOds" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -457,7 +591,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "noOdsChange" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -466,14 +600,15 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
             },
             originator: {
-              odsCode: "X123"
+              odsCode: "X123",
             },
             personalisation: {},
           },
         },
       })
       .expect(400, {
-        message: "odsCode was provided but ODS code override is not enabled for the client",
+        message:
+          "odsCode was provided but ODS code override is not enabled for the client",
       })
       .expect("Content-Type", /json/, done);
   });
@@ -484,7 +619,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -492,7 +627,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                email: 'hello'
+                email: "hello",
               },
             },
             personalisation: {},
@@ -509,7 +644,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "notAllowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -517,7 +652,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                sms: 'hello'
+                sms: "hello",
               },
             },
             personalisation: {},
@@ -536,7 +671,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -544,7 +679,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                sms: 'hello'
+                sms: "hello",
               },
             },
             personalisation: {},
@@ -561,7 +696,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -569,7 +704,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                sms: '07700900002'
+                sms: "07700900002",
               },
             },
             personalisation: {},
@@ -577,14 +712,15 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'sms': Input failed format check",
+        message:
+          "Invalid recipient contact details. Field 'sms': Input failed format check",
         errors: [
           {
             field: "/data/attributes/recipient/contactDetails/sms",
             message: "Input failed format check",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -595,7 +731,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -604,8 +740,8 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 sms: {
-                  hello: 1
-                }
+                  hello: 1,
+                },
               },
             },
             personalisation: {},
@@ -618,9 +754,9 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/sms",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -631,7 +767,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -639,7 +775,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                email: 'hello'
+                email: "hello",
               },
             },
             personalisation: {},
@@ -648,7 +784,7 @@ describe("/api/v1/messages", () => {
       })
       .expect(201)
       .expect("Content-Type", /json/, done);
-  })
+  });
 
   it("returns a 400 when invalid email alternate contact detail is provided", (done) => {
     request(server)
@@ -656,7 +792,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -664,7 +800,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                email: 'invalidEmailAddress'
+                email: "invalidEmailAddress",
               },
             },
             personalisation: {},
@@ -672,14 +808,15 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'email': Input failed format check",
+        message:
+          "Invalid recipient contact details. Field 'email': Input failed format check",
         errors: [
           {
             field: "/data/attributes/recipient/contactDetails/email",
             message: "Input failed format check",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -690,7 +827,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -699,8 +836,8 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 email: {
-                  hello: 1
-                }
+                  hello: 1,
+                },
               },
             },
             personalisation: {},
@@ -713,9 +850,9 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/email",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -726,7 +863,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -735,9 +872,9 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1', '2'],
-                  postcode: 'hello'
-                }
+                  lines: ["1", "2"],
+                  postcode: "hello",
+                },
               },
             },
             personalisation: {},
@@ -754,7 +891,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -762,7 +899,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                address: 'hello'
+                address: "hello",
               },
             },
             personalisation: {},
@@ -775,9 +912,9 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -788,7 +925,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -796,7 +933,7 @@ describe("/api/v1/messages", () => {
               nhsNumber: "1",
               dateOfBirth: "1",
               contactDetails: {
-                address: []
+                address: [],
               },
             },
             personalisation: {},
@@ -809,9 +946,9 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -822,7 +959,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -831,9 +968,9 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: 'test',
-                  postcode: 'test'
-                }
+                  lines: "test",
+                  postcode: "test",
+                },
               },
             },
             personalisation: {},
@@ -841,14 +978,15 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'lines': 'lines' is missing",
+        message:
+          "Invalid recipient contact details. Field 'lines': 'lines' is missing",
         errors: [
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "`lines` is missing",
-            title: "Missing value"
-          }
-        ]
+            title: "Missing value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -859,7 +997,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -868,9 +1006,9 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1'],
-                  postcode: 'hello'
-                }
+                  lines: ["1"],
+                  postcode: "hello",
+                },
               },
             },
             personalisation: {},
@@ -878,14 +1016,15 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'lines': Too few address lines were provided",
+        message:
+          "Invalid recipient contact details. Field 'lines': Too few address lines were provided",
         errors: [
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Missing value"
-          }
-        ]
+            title: "Missing value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -896,7 +1035,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -905,9 +1044,9 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1', '2', '3', '4', '5', '6'],
-                  postcode: 'hello'
-                }
+                  lines: ["1", "2", "3", "4", "5", "6"],
+                  postcode: "hello",
+                },
               },
             },
             personalisation: {},
@@ -920,9 +1059,9 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -933,7 +1072,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -942,9 +1081,9 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1', '2', 3, '4', '5'],
-                  postcode: 'hello'
-                }
+                  lines: ["1", "2", 3, "4", "5"],
+                  postcode: "hello",
+                },
               },
             },
             personalisation: {},
@@ -957,9 +1096,9 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -970,7 +1109,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -979,8 +1118,8 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1', '2'],
-                }
+                  lines: ["1", "2"],
+                },
               },
             },
             personalisation: {},
@@ -988,14 +1127,15 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'postcode': 'postcode' is missing",
+        message:
+          "Invalid recipient contact details. Field 'postcode': 'postcode' is missing",
         errors: [
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "`postcode` is missing",
-            title: "Missing value"
-          }
-        ]
+            title: "Missing value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
@@ -1006,7 +1146,7 @@ describe("/api/v1/messages", () => {
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -1015,9 +1155,9 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1', '2'],
-                  postcode: []
-                }
+                  lines: ["1", "2"],
+                  postcode: [],
+                },
               },
             },
             personalisation: {},
@@ -1030,19 +1170,19 @@ describe("/api/v1/messages", () => {
           {
             field: "/data/attributes/recipient/contactDetails/address/postcode",
             message: "Invalid",
-            title: "Invalid value"
-          }
-        ]
+            title: "Invalid value",
+          },
+        ],
       })
       .expect("Content-Type", /json/, done);
   });
-  it('returns a 400 and multiple errors when there are multiple issues in contact details provided', (done) => {
+  it("returns a 400 and multiple errors when there are multiple issues in contact details provided", (done) => {
     request(server)
       .post("/api/v1/messages")
       .set({ Authorization: "allowedContactDetailOverride" })
       .send({
         data: {
-          type: 'Message',
+          type: "Message",
           attributes: {
             routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
             messageReference: "b5bb84b9-a522-41e9-aa8b-ad1b6a454243",
@@ -1051,10 +1191,10 @@ describe("/api/v1/messages", () => {
               dateOfBirth: "1",
               contactDetails: {
                 address: {
-                  lines: ['1'],
-                  postcode: []
+                  lines: ["1"],
+                  postcode: [],
                 },
-                email: 'invalidEmailAddress'
+                email: "invalidEmailAddress",
               },
             },
             personalisation: {},
@@ -1062,51 +1202,51 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'email': Input failed format check. Field 'lines': Too few address lines were provided",
+        message:
+          "Invalid recipient contact details. Field 'email': Input failed format check. Field 'lines': Too few address lines were provided",
         errors: [
           {
             field: "/data/attributes/recipient/contactDetails/email",
             message: "Input failed format check",
-            title: "Invalid value"
+            title: "Invalid value",
           },
           {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Missing value"
+            title: "Missing value",
           },
-        ]
+        ],
       })
       .expect("Content-Type", /json/, done);
-  })
+  });
 
   it("returns a 201 when all alternate contact details are provided", (done) => {
     request(server)
       .post("/api/v1/messages")
       .set({ Authorization: "allowedContactDetailOverride" })
-      .send(
-        {
-          data: {
-            type: "Message",
-            attributes: {
-              routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-              messageBatchReference: "request-id",
-              messageReference: "1",
-              recipient: {
-                nhsNumber: "1",
-                dateOfBirth: "1",
-                contactDetails: {
-                  email: 'hello',
-                  sms: 'hello',
-                  address: {
-                    lines: ['1', '2'],
-                    postcode: 'hello'
-                  }
-                }
+      .send({
+        data: {
+          type: "Message",
+          attributes: {
+            routingPlanId: "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+            messageBatchReference: "request-id",
+            messageReference: "1",
+            recipient: {
+              nhsNumber: "1",
+              dateOfBirth: "1",
+              contactDetails: {
+                email: "hello",
+                sms: "hello",
+                address: {
+                  lines: ["1", "2"],
+                  postcode: "hello",
+                },
               },
             },
           },
-        })
+        },
+      })
       .expect(201)
       .expect("Content-Type", /json/, done);
   });
-})
+});

--- a/sandbox/handlers/batch_send.js
+++ b/sandbox/handlers/batch_send.js
@@ -1,16 +1,10 @@
-import KSUID from "ksuid"
-import {
-  sendError,
-  writeLog,
-  hasValidGlobalTemplatePersonalisation,
-} from "./utils.js"
-import {
-  globalFreeTextNhsAppSendingGroupId,
-} from "./config.js"
-import { getSendingGroupIdError } from "./error_scenarios/sending_group_id.js"
-import { getOdsCodeError } from "./error_scenarios/ods_code.js"
-import { mandatoryBatchMessageFieldValidation } from "./validation/mandatory_batch_message_fields.js"
-import { getAlternateContactDetailsError } from "./error_scenarios/override_contact_details.js"
+import KSUID from "ksuid";
+import { sendError, writeLog } from "./utils.js";
+import { getGlobalFreeTextError } from "./error_scenarios/global_free_text.js";
+import { getSendingGroupIdError } from "./error_scenarios/sending_group_id.js";
+import { getOdsCodeError } from "./error_scenarios/ods_code.js";
+import { mandatoryBatchMessageFieldValidation } from "./validation/mandatory_batch_message_fields.js";
+import { getAlternateContactDetailsError } from "./error_scenarios/override_contact_details.js";
 
 export async function batchSend(req, res, next) {
   const { headers, body } = req;
@@ -24,64 +18,68 @@ export async function batchSend(req, res, next) {
     return;
   }
 
-  const mandatoryFieldError = mandatoryBatchMessageFieldValidation(body)
+  const mandatoryFieldError = mandatoryBatchMessageFieldValidation(body);
   if (mandatoryFieldError !== null) {
-    const [errorCode, errorMessage] = mandatoryFieldError
-    sendError(res, errorCode, errorMessage)
-    next()
-    return;
-  }
-
-  const { routingPlanId, messages } = body.data.attributes
-
-  if (
-    routingPlanId === globalFreeTextNhsAppSendingGroupId &&
-    messages.findIndex(
-      (message) =>
-        !hasValidGlobalTemplatePersonalisation(message.personalisation)
-    ) > -1
-  ) {
-    sendError(res, 400, "Expect single personalisation field of 'body'");
+    const [errorCode, errorMessage] = mandatoryFieldError;
+    sendError(res, errorCode, errorMessage);
     next();
     return;
   }
 
-  const odsCodes = messages.map((message) => message && message.originator?.odsCode)
-  for (const odsCode of odsCodes) {
-    const odsCodeError = getOdsCodeError(odsCode, req.headers.authorization)
+  const { routingPlanId, messages } = body.data.attributes;
 
-    if (odsCodeError !== null) {
-      const [errorCode, errorMessage] = odsCodeError
-      sendError(res, errorCode, errorMessage)
-      next()
+  const messagePersonsalisations = messages.map(
+    (message) => message.personalisation
+  );
+  for (const personalisation of messagePersonsalisations) {
+    const globalFreeTextError = getGlobalFreeTextError(
+      personalisation,
+      routingPlanId
+    );
+
+    if (globalFreeTextError !== null) {
+      const [errorCode, errorMessage] = globalFreeTextError;
+      sendError(res, errorCode, errorMessage);
+      next();
       return;
     }
   }
 
-  const sendingGroupIdError = getSendingGroupIdError(routingPlanId)
+  const odsCodes = messages.map(
+    (message) => message && message.originator?.odsCode
+  );
+  for (const odsCode of odsCodes) {
+    const odsCodeError = getOdsCodeError(odsCode, req.headers.authorization);
+
+    if (odsCodeError !== null) {
+      const [errorCode, errorMessage] = odsCodeError;
+      sendError(res, errorCode, errorMessage);
+      next();
+      return;
+    }
+  }
+
+  const sendingGroupIdError = getSendingGroupIdError(routingPlanId);
   if (sendingGroupIdError !== null) {
-    const [errorCode, errorMessage] = sendingGroupIdError
-    sendError(
-      res,
-      errorCode,
-      errorMessage
-    )
-    next()
+    const [errorCode, errorMessage] = sendingGroupIdError;
+    sendError(res, errorCode, errorMessage);
+    next();
     return;
   }
 
-  const alternateContactDetails = messages.map((message) => message.recipient?.contactDetails)
+  const alternateContactDetails = messages.map(
+    (message) => message.recipient?.contactDetails
+  );
   for (const contactDetail of alternateContactDetails) {
-    const alternateContactDetailsError = getAlternateContactDetailsError(contactDetail, req.headers.authorization, '/data/attributes/messages')
+    const alternateContactDetailsError = getAlternateContactDetailsError(
+      contactDetail,
+      req.headers.authorization,
+      "/data/attributes/messages"
+    );
     if (alternateContactDetailsError !== null) {
-      const [errorCode, errorMessage, errors] = alternateContactDetailsError
-      sendError(
-        res,
-        errorCode,
-        errorMessage,
-        errors
-      )
-      next()
+      const [errorCode, errorMessage, errors] = alternateContactDetailsError;
+      sendError(res, errorCode, errorMessage, errors);
+      next();
       return;
     }
   }

--- a/sandbox/handlers/config.js
+++ b/sandbox/handlers/config.js
@@ -5,20 +5,26 @@ const sendingGroupIdWithMissingTemplates = "c8857ccf-06ec-483f-9b3a-7fc732d9ad48
 const sendingGroupIdWithDuplicateTemplates = "a3a4e55d-7a21-45a6-9286-8eb595c872a8";
 const sendingGroupIdWithMissingNHSTemplates = "aeb16ab8-cb9c-4d23-92e9-87c78119175c";
 const globalFreeTextNhsAppSendingGroupId = "00000000-0000-0000-0000-000000000001";
+const globalFreeTextEmailSendingGroupId = "00000000-0000-0000-0000-000000000002";
+const globalFreeTextSmsSendingGroupId = "00000000-0000-0000-0000-000000000003";
+
 const validSendingGroupIds = {
     "b838b13c-f98c-4def-93f0-515d4e4f4ee1": "ztoe2qRAM8M8vS0bqajhyEBcvXacrGPp",
     "49e43b98-70cb-47a9-a55e-fe70c9a6f77c": "G.uwELAFAGMsKEBk2iIeRCBOB6kj6OkE",
     "b402cd20-b62a-4357-8e02-2952959531c8": "J7ZPQIf1yyUB4CiBpUBoy.1ahfOTCCQ7",
     "936e9d45-15de-4a95-bb36-ae163c33ae53": "riOAKoN4ajoVyUf9U2xwHVNRHc5V52A.",
     "9ba00d23-cd6f-4aca-8688-00abc85a7980": "nkz2osS_oc8IZ5GqeN_1yXKSXe9VEUjV",
+    [invalidRoutingPlanId]: "c889ViFFlqtDdgV9E2KH.w58T5I71_x_",
+    [sendingGroupIdWithMissingTemplates]: "EaSC3Wy4BC8Kuk.hZjI95F1f9mZIkP9l",
+    [sendingGroupIdWithDuplicateTemplates]: "3t.Ofz4i.NO83.tBDLhRpyClu.sGCxTU",
+    [trigger500SendingGroupId]: "Jc96S9y4AKjncXndUXiS7M7yIZ3jNtY1",
+    [trigger425SendingGroupId]: "_oivtOz8fHRXhtZAyFxJmT2j_xpWzq9s",
+    [sendingGroupIdWithMissingNHSTemplates]: "DjAAu455M2TMq0VKEaD_1WZfwjkspJDL",
+    [globalFreeTextNhsAppSendingGroupId]: "odbGpMQvYRM7sp7jueU2lRHQiueKujVO",
+    [globalFreeTextEmailSendingGroupId]: "HXdzlIX2Rv2qy7j9MR3FxbPHhJM7Jjzt",
+    [globalFreeTextSmsSendingGroupId]: "xoERWoahq12cq8WMXya4yed9hZtZbMxJ"
 };
-validSendingGroupIds[invalidRoutingPlanId] = "c889ViFFlqtDdgV9E2KH.w58T5I71_x_";
-validSendingGroupIds[sendingGroupIdWithMissingTemplates] = "EaSC3Wy4BC8Kuk.hZjI95F1f9mZIkP9l";
-validSendingGroupIds[sendingGroupIdWithDuplicateTemplates] = "3t.Ofz4i.NO83.tBDLhRpyClu.sGCxTU";
-validSendingGroupIds[trigger500SendingGroupId] = "Jc96S9y4AKjncXndUXiS7M7yIZ3jNtY1";
-validSendingGroupIds[trigger425SendingGroupId] = "_oivtOz8fHRXhtZAyFxJmT2j_xpWzq9s";
-validSendingGroupIds[sendingGroupIdWithMissingNHSTemplates] = "DjAAu455M2TMq0VKEaD_1WZfwjkspJDL";
-validSendingGroupIds[globalFreeTextNhsAppSendingGroupId] = "odbGpMQvYRM7sp7jueU2lRHQiueKujVO";
+
 const invalidEmailAddress = "invalidEmailAddress";
 
 const duplicateTemplates = [
@@ -58,6 +64,8 @@ export {
     validSendingGroupIds,
     duplicateTemplates,
     globalFreeTextNhsAppSendingGroupId,
+    globalFreeTextEmailSendingGroupId,
+    globalFreeTextSmsSendingGroupId,
     noDefaultOdsClientAuth,
     noOdsChangeClientAuth,
     notAllowedContactDetailOverride,

--- a/sandbox/handlers/error_scenarios/global_free_text.js
+++ b/sandbox/handlers/error_scenarios/global_free_text.js
@@ -1,0 +1,50 @@
+import {
+  globalFreeTextEmailSendingGroupId,
+  globalFreeTextNhsAppSendingGroupId,
+  globalFreeTextSmsSendingGroupId,
+} from "../config.js";
+
+const globalFreeTextPersonalisationFields = {
+  [globalFreeTextNhsAppSendingGroupId]: ["body"],
+  [globalFreeTextEmailSendingGroupId]: ["email_subject", "email_body"],
+  [globalFreeTextSmsSendingGroupId]: ["sms_body"],
+};
+
+export function getGlobalFreeTextError(personalisation, sendingGroupId) {
+  const requiredPersonalisationFields =
+    globalFreeTextPersonalisationFields[sendingGroupId];
+
+  if (!requiredPersonalisationFields) {
+    return null;
+  }
+
+  if (!personalisation) {
+    return [
+      400,
+      `Some personalisation fields are missing: ${requiredPersonalisationFields.join(
+        ","
+      )}`,
+    ];
+  }
+
+  const personalisationFields = Object.keys(personalisation);
+
+  const missingPersonalisationFields = [];
+
+  for (const requiredField of requiredPersonalisationFields) {
+    if (!personalisationFields.includes(requiredField)) {
+      missingPersonalisationFields.push(requiredField);
+    }
+  }
+
+  if (missingPersonalisationFields.length) {
+    return [
+      400,
+      `Some personalisation fields are missing: ${missingPersonalisationFields.join(
+        ","
+      )}`,
+    ];
+  }
+
+  return null;
+}

--- a/sandbox/handlers/messages.js
+++ b/sandbox/handlers/messages.js
@@ -1,13 +1,11 @@
 import KSUID from "ksuid";
-import { sendError, writeLog, hasValidGlobalTemplatePersonalisation } from "./utils.js";
-import {
-  validSendingGroupIds,
-  globalFreeTextNhsAppSendingGroupId,
-} from "./config.js"
+import { sendError, writeLog } from "./utils.js";
+import { validSendingGroupIds } from "./config.js";
 import { getSendingGroupIdError } from "./error_scenarios/sending_group_id.js";
 import { getOdsCodeError } from "./error_scenarios/ods_code.js";
 import { mandatorySingleMessageFieldValidation } from "./validation/mandatory_single_message_fields.js";
 import { getAlternateContactDetailsError } from "./error_scenarios/override_contact_details.js";
+import { getGlobalFreeTextError } from "./error_scenarios/global_free_text.js";
 
 export async function messages(req, res, next) {
   if (req.headers.authorization === "banned") {
@@ -20,57 +18,56 @@ export async function messages(req, res, next) {
     return;
   }
 
-  const mandatoryFieldError = mandatorySingleMessageFieldValidation(req.body)
+  const mandatoryFieldError = mandatorySingleMessageFieldValidation(req.body);
   if (mandatoryFieldError !== null) {
-    const [errorCode, errorMessage] = mandatoryFieldError
-    sendError(res, errorCode, errorMessage)
-    next()
+    const [errorCode, errorMessage] = mandatoryFieldError;
+    sendError(res, errorCode, errorMessage);
+    next();
     return;
   }
 
   const { routingPlanId } = req.body.data.attributes;
 
-  const sendingGroupIdError = getSendingGroupIdError(routingPlanId)
+  const sendingGroupIdError = getSendingGroupIdError(routingPlanId);
   if (sendingGroupIdError !== null) {
-    const [errorCode, errorMessage] = sendingGroupIdError
-    sendError(
-      res,
-      errorCode,
-      errorMessage
-    )
-    next()
+    const [errorCode, errorMessage] = sendingGroupIdError;
+    sendError(res, errorCode, errorMessage);
+    next();
     return;
   }
 
-  if (
-    routingPlanId === globalFreeTextNhsAppSendingGroupId &&
-    !hasValidGlobalTemplatePersonalisation(req.body.data.attributes.personalisation)
-  ) {
-    sendError(res, 400, "Expect single personalisation field of 'body'");
+  const personalisation = req.body.data?.attributes?.personalisation;
+  const globalFreeTextError = getGlobalFreeTextError(
+    personalisation,
+    routingPlanId
+  );
+  if (globalFreeTextError !== null) {
+    const [errorCode, errorMessage] = globalFreeTextError;
+    sendError(res, errorCode, errorMessage);
     next();
     return;
   }
 
   const odsCode = req.body.data?.attributes?.originator?.odsCode;
-  const odsCodeError = getOdsCodeError(odsCode, req.headers.authorization)
+  const odsCodeError = getOdsCodeError(odsCode, req.headers.authorization);
   if (odsCodeError !== null) {
-    const [odsCodeErrorCode, odsCodeErrorMessage] = odsCodeError
-    sendError(res, odsCodeErrorCode, odsCodeErrorMessage)
-    next()
+    const [errorCode, errorMessage] = odsCodeError;
+    sendError(res, errorCode, errorMessage);
+    next();
     return;
   }
 
-  const alternateContactDetails = req.body.data?.attributes?.recipient?.contactDetails
-  const alternateContactDetailsError = getAlternateContactDetailsError(alternateContactDetails, req.headers.authorization, '/data/attributes')
+  const alternateContactDetails =
+    req.body.data?.attributes?.recipient?.contactDetails;
+  const alternateContactDetailsError = getAlternateContactDetailsError(
+    alternateContactDetails,
+    req.headers.authorization,
+    "/data/attributes"
+  );
   if (alternateContactDetailsError !== null) {
-    const [errorCode, errorMessage, errors] = alternateContactDetailsError
-    sendError(
-      res,
-      errorCode,
-      errorMessage,
-      errors
-    )
-    next()
+    const [errorCode, errorMessage, errors] = alternateContactDetailsError;
+    sendError(res, errorCode, errorMessage, errors);
+    next();
     return;
   }
 

--- a/sandbox/handlers/utils.js
+++ b/sandbox/handlers/utils.js
@@ -44,18 +44,3 @@ export function sendError(res, code, message, errors) {
   });
 }
 
-export function hasValidGlobalTemplatePersonalisation(personalisation) {
-  if (!personalisation) {
-    return false;
-  }
-
-  const personalisationFields = Object.keys(personalisation);
-  if (personalisationFields.length !== 1) {
-    return false;
-  }
-
-  if (personalisationFields[0] !== "body") {
-    return false;
-  }
-  return true;
-}


### PR DESCRIPTION
## Summary

- Added global free text SMS and Email routing configs to sandbox
- Updated error message that was returned when NHS App free text personalisation field was missing to align with the error returned in the BE
   - Before: `Expect single personalisation field of 'body'`
   -  After: `Some personalisation fields are missing: body` 
- Updated logic so that if unrecognised personalisation parameter is provided but required parameters have also been provided, sandbox returns 200/201 instead of 400. This aligns with validation in the BE


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
