### PR TITLE
CCM-6362: add global timeout for expect functions

### DIFF
--- a/tests/lib/helper.py
+++ b/tests/lib/helper.py
@@ -69,6 +69,7 @@ class Helper():
             browser = playwright.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(15000)
+            expect.set_options(timeout=15000)
 
             page.goto("https://www-onboardingaos.nhsapp.service.nhs.uk/login")
 


### PR DESCRIPTION
## Summary

Add a global timeout for expect functions 

## Reviews Required
* [] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
