### PR TITLE
CCM-6648: Fix intermittent 401 errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ TEST_CMD := @APIGEE_ACCESS_TOKEN="$(APIGEE_ACCESS_TOKEN)" \
 		--reruns-delay 5 \
 		--only-rerun 'AssertionError: Unexpected 429' \
 		--only-rerun 'AssertionError: Unexpected 504' \
+		--only-rerun 'AssertionError: Unexpected 401' \
 	    --junitxml=test-report.xml
 
 PERFTEST_CMD := @APIGEE_ACCESS_TOKEN="$(APIGEE_ACCESS_TOKEN)" \

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -243,15 +243,7 @@ class Assertions():
 
     @staticmethod
     def assert_error_with_optional_correlation_id(resp, code, error, correlation_id):
-        if code == 429:
-            # If we are testing a 429 error then only retry on 504 errors
-            error_handler.handle_504_retry(resp)
-        elif code == 504:
-            # If we are testing a 504 error then only retry on 429 errors
-            error_handler.handle_429_retry(resp)
-        else:
-            # We are not testing a 429 or 504, retry if we get either of them
-            error_handler.handle_retry(resp)
+        error_handler.handle_retry(resp, excluded_code=code)
 
         assert resp.status_code == code, f"Response: {resp.status_code}: {resp.text}"
 

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -243,7 +243,9 @@ class Assertions():
 
     @staticmethod
     def assert_error_with_optional_correlation_id(resp, code, error, correlation_id):
-        error_handler.handle_retry(resp, excluded_code=code)
+        if resp.status_code != code:
+            # Unexpected status code, check if the test needs to be retried
+            error_handler.handle_retry(resp)
 
         assert resp.status_code == code, f"Response: {resp.status_code}: {resp.text}"
 

--- a/tests/lib/authentication.py
+++ b/tests/lib/authentication.py
@@ -11,7 +11,7 @@ class AuthenticationCache():
     def __init__(self):
         self.tokens = {}
 
-        # Number of consecutive authentication tests before considering it is successful.
+        # Number of consecutive authentication tests before considering it worked.
         # This is required because apigee might be using load balancing.
         self.consecutive_tests = 4
 
@@ -70,18 +70,18 @@ class AuthenticationCache():
     def generate_and_test_new_token(self, api_key, private_key, url, kid, test_url):
         new_token = None
         valid_auth = False
-        time_since_new_token = int(time())
 
         for i in range(self.max_tests):
             print(f"Testing new token, attemp #{i+1}")
             if new_token is None:
                 new_token = self.generate_new_token(api_key, private_key, url, kid)
+                time_since_new_token = int(time())
 
             if self.test_token(test_url, new_token[0]):
                 valid_auth = True
                 break
 
-            # The test fail, give apigee some time to update its cache.
+            # The test failed, give apigee some time to update its cache.
             time.sleep(self.time_between_tests)
 
             if int(time()) - time_since_new_token > (self.token_validity / 2):

--- a/tests/lib/authentication.py
+++ b/tests/lib/authentication.py
@@ -11,28 +11,50 @@ class AuthenticationCache():
     def __init__(self):
         self.tokens = {}
 
+        # Number of consecutive authentication tests before considering it is successful.
+        # This is required because apigee might be using load balancing.
+        self.consecutive_tests = 4
+
+        # Number of seconds before trying a test again
+        self.time_between_tests = 10
+
+        # Number of attempts before giving up. It can take up to 5 minutes for the
+        # addition of a product to an application to take effect.
+        # time_between_tests * max_tests = 300 seconds = 5 minutes.
+        self.max_tests = 30
+
+        # How long the token will stay valid
+        self.token_validity = 180
+
     def generate_authentication(self, env):
 
+        # For the test_url, note that we don't need a message_id that actually exists in
+        # the backend. The test will only check that the API doesn't return a 401,
+        # a 404 response means the authentication is working.
         if env == "internal-dev":
             api_key = os.environ["NON_PROD_API_KEY"]
             private_key = os.environ["NON_PROD_PRIVATE_KEY"]
             url = "https://internal-dev.api.service.nhs.uk/oauth2/token"
             kid = "local"
+            test_url = "https://internal-dev.api.service.nhs.uk/comms/v1/messages/message_id"
         elif env == "internal-dev-test-1":
             api_key = os.environ["NON_PROD_API_KEY_TEST_1"]
             private_key = os.environ["NON_PROD_PRIVATE_KEY"]
             url = "https://internal-dev.api.service.nhs.uk/oauth2/token"
             kid = "local"
+            test_url = "https://internal-dev.api.service.nhs.uk/comms/v1/messages/message_id"
         elif env == "int":
             api_key = os.environ.get("INTEGRATION_API_KEY")
             private_key = os.environ.get("INTEGRATION_PRIVATE_KEY")
             url = "https://int.api.service.nhs.uk/oauth2/token"
             kid = "local"
+            test_url = "https://int.api.service.nhs.uk/comms/v1/messages/message_id"
         elif env == "prod":
             api_key = os.environ.get("PRODUCTION_API_KEY")
             private_key = os.environ.get("PRODUCTION_PRIVATE_KEY")
             url = "https://api.service.nhs.uk/oauth2/token"
             kid = "prod-1"
+            test_url = "https://api.service.nhs.uk/comms/v1/messages/message_id"
         else:
             raise ValueError("Unknown value: ", env)
 
@@ -40,36 +62,82 @@ class AuthenticationCache():
 
         # Generate new token if latest token will expire in 15 seconds
         if env not in self.tokens or latest_token_expiry < int(time()) + 15:
-            pk_pem = None
-            with open(private_key, "r") as f:
-                pk_pem = f.read()
-
-            token_expiry = int(time()) + 180
-
-            claims = {
-                "sub": api_key,
-                "iss": api_key,
-                "jti": str(uuid.uuid4()),
-                "aud": url,
-                "exp": token_expiry,
-            }
-            additional_headers = {"kid": kid}
-
-            j = jwt.encode(
-                claims, pk_pem, algorithm="RS512", headers=additional_headers
-            )
-
-            resp = requests.post(url, headers={
-                "Content-Type": "application/x-www-form-urlencoded"
-            }, data={
-                "grant_type": "client_credentials",
-                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                "client_assertion": j
-            }
-            )
-            details = json.loads(resp.content)
-
-            self.tokens[env] = (f"Bearer {details.get('access_token')}", token_expiry)
+            self.tokens[env] = self.generate_and_test_new_token(api_key, private_key, url, kid, test_url)
 
         bearer_token = self.tokens[env][0]
         return Secret(bearer_token)
+
+    def generate_and_test_new_token(self, api_key, private_key, url, kid, test_url):
+        new_token = None
+        valid_auth = False
+        time_since_new_token = int(time())
+
+        for i in range(self.max_tests):
+            print(f"Testing new token, attemp #{i+1}")
+            if new_token is None:
+                new_token = self.generate_new_token(api_key, private_key, url, kid)
+
+            if self.test_token(test_url, new_token[0]):
+                valid_auth = True
+                break
+
+            # The test fail, give apigee some time to update its cache.
+            time.sleep(self.time_between_tests)
+
+            if int(time()) - time_since_new_token > (self.token_validity / 2):
+                # Token about to expire, generate a new one
+                new_token = None
+
+        if valid_auth:
+            print("Token generated successfully")
+            return new_token
+
+        print("Could not generate token")
+        raise Exception("Could not generate token")
+
+    def generate_new_token(self, api_key, private_key, url, kid):
+        pk_pem = None
+        with open(private_key, "r") as f:
+            pk_pem = f.read()
+
+        token_expiry = int(time()) + self.token_validity
+
+        claims = {
+            "sub": api_key,
+            "iss": api_key,
+            "jti": str(uuid.uuid4()),
+            "aud": url,
+            "exp": token_expiry,
+        }
+        additional_headers = {"kid": kid}
+
+        j = jwt.encode(
+            claims, pk_pem, algorithm="RS512", headers=additional_headers
+        )
+
+        resp = requests.post(url, headers={
+            "Content-Type": "application/x-www-form-urlencoded"
+        }, data={
+            "grant_type": "client_credentials",
+            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion": j
+        }
+        )
+        details = json.loads(resp.content)
+
+        return (f"Bearer {details.get('access_token')}", token_expiry)
+
+    def test_token(self, test_url, token):
+        for _ in range(self.consecutive_tests):
+            resp = requests.get(
+                test_url,
+                headers={
+                    "Authorization": token,
+                    "Accept": "*/*",
+                    "Content-Type": "application/json"
+                },
+            )
+            if resp.status_code == 401:
+                return False
+
+        return True

--- a/tests/lib/authentication.py
+++ b/tests/lib/authentication.py
@@ -31,7 +31,7 @@ class AuthenticationCache():
         # For the test_url, note that we don't need a message_id that actually exists in
         # the backend. The test will only check that the API doesn't return a 401,
         # a 404 response means the authentication is working.
-        test_url = f"{base_url}/v1/messages"
+        test_url = f"{base_url}/v1/messages/message_id"
 
         if env == "internal-dev":
             api_key = os.environ["NON_PROD_API_KEY"]

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -40,8 +40,6 @@ INT_API_GATEWAY_URL = "https://comms-apim.int.communications.national.nhs.uk"
 PROD_API_GATEWAY_URL = "https://comms-apim.prod.communications.national.nhs.uk"
 UAT_API_GATEWAY_URL = "https://comms-apim.uat.communications.national.nhs.uk"
 DEFAULT_CONTENT_TYPE = "application/vnd.api+json"
-UNEXPECTED_429 = AssertionError('Unexpected 429')
-UNEXPECTED_504 = AssertionError('Unexpected 504')
 
 VALID_ACCEPT_HEADERS = ["*/*", DEFAULT_CONTENT_TYPE]
 VALID_CONTENT_TYPE_HEADERS = [DEFAULT_CONTENT_TYPE]

--- a/tests/lib/error_handler.py
+++ b/tests/lib/error_handler.py
@@ -1,18 +1,11 @@
 import lib.constants.constants as constants
 
+codes_to_retry = [401, 429, 504]
+
 
 class error_handler():
     @staticmethod
-    def handle_retry(resp):
-        error_handler.handle_429_retry(resp)
-        error_handler.handle_504_retry(resp)
-
-    @staticmethod
-    def handle_429_retry(resp):
-        if resp.status_code == 429:
-            raise constants.UNEXPECTED_429
-
-    @staticmethod
-    def handle_504_retry(resp):
-        if resp.status_code == 504:
-            raise constants.UNEXPECTED_504
+    def handle_retry(resp, excluded_code=None):
+        for code_to_retry in codes_to_retry:
+            if code_to_retry != excluded_code and code_to_retry == resp.status_code:
+                raise AssertionError(f'Unexpected {code_to_retry}')

--- a/tests/lib/error_handler.py
+++ b/tests/lib/error_handler.py
@@ -5,7 +5,6 @@ codes_to_retry = [401, 429, 504]
 
 class error_handler():
     @staticmethod
-    def handle_retry(resp, excluded_code=None):
-        for code_to_retry in codes_to_retry:
-            if code_to_retry != excluded_code and code_to_retry == resp.status_code:
-                raise AssertionError(f'Unexpected {code_to_retry}')
+    def handle_retry(resp):
+        if resp.status_code in codes_to_retry:
+            raise AssertionError(f'Unexpected {resp.status_code}')

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -3,6 +3,7 @@ import os
 from .authentication import AuthenticationCache
 from .app_keys import ensure_api_product_in_application, ensure_api_product_not_in_application
 from .rate_limiting import RateLimiting
+from lib.constants.constants import INT_URL, PROD_URL
 
 
 @pytest.fixture(scope='session')
@@ -73,23 +74,25 @@ def authentication_cache():
 
 
 @pytest.fixture
-def bearer_token_internal_dev(authentication_cache, api_product_in_comms_manager_local):
-    return authentication_cache.generate_authentication('internal-dev')
+def bearer_token_internal_dev(authentication_cache, api_product_in_comms_manager_local, nhsd_apim_proxy_url):
+    return authentication_cache.generate_authentication('internal-dev', nhsd_apim_proxy_url)
 
 
 @pytest.fixture
-def bearer_token_internal_dev_test_1(authentication_cache, api_product_in_nhs_notify_test_client_1):
-    return authentication_cache.generate_authentication('internal-dev-test-1')
+def bearer_token_internal_dev_test_1(authentication_cache,
+                                     api_product_in_nhs_notify_test_client_1,
+                                     nhsd_apim_proxy_url):
+    return authentication_cache.generate_authentication('internal-dev-test-1', nhsd_apim_proxy_url)
 
 
 @pytest.fixture
 def bearer_token_int(authentication_cache):
-    return authentication_cache.generate_authentication('int')
+    return authentication_cache.generate_authentication('int', INT_URL)
 
 
 @pytest.fixture
 def bearer_token_prod(authentication_cache):
-    return authentication_cache.generate_authentication('prod')
+    return authentication_cache.generate_authentication('prod', PROD_URL)
 
 
 @pytest.fixture(scope='session')

--- a/tests/sandbox/test_500_errors.py
+++ b/tests/sandbox/test_500_errors.py
@@ -20,8 +20,6 @@ def test_internal_server_error_get(nhsd_apim_proxy_url, correlation_id, method):
         "X-Correlation-Id": correlation_id
     })
 
-    error_handler.handle_504_retry(resp)
-
     Assertions.assert_error_with_optional_correlation_id(
         resp,
         500,


### PR DESCRIPTION
## Summary

Edit: Unfortunately we still got 401 errors after implementing the solution below because we can get 100s of successful tests before getting random failures. I think we can still keep this solution but I also added retries for individual tests.

It can take up to 5 minutes for Apigee to register that a Product has been added to an Application. This can sometimes cause APIM tests to fail because of 401 errors (and tests that are expecting 401s to be false positives).

Some logic has been added to the token generation for tests in order to test the token multiple times to make sure the authentication is working before proceeding to the tests. If the authentication is not ready (the test request returns a 401) then the logic waits 10 seconds before trying again.

One would think the correct place for this would be where the product is added to the application but an auth token is not easily available from there and that piece of code is currently independent from the environment it's running on, whereas auth tokens do depend on the environment. I think it also makes sense to test a token at the time it's generated.

![Token Generation drawio](https://github.com/user-attachments/assets/ad20747f-5e04-403d-b8ec-c4a9b5895e81)


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
