### PR TITLE
CCM-7379: remove references to deduplicating requests in api docs

### DIFF
--- a/specification/documentation/CreateMessage.md
+++ b/specification/documentation/CreateMessage.md
@@ -10,8 +10,6 @@ This reference must be a [Universal Unique Identifier (UUID)](https://en.wikiped
 
 The message reference (`messageReference`) needs to be unique across all single messages you have sent. This value is used to store your reference for this specific message and can be used if you lose (or do not recieve) our unique identifier in the response.
 
-If you send through a request with the same `messageReference` on it then the system will respond with the same response as the first time the message was created.
-
 ### Personalisation
 
 You may be required to send through specific personalisation fields based upon the routing plan (`routingPlanId`). These will have been setup during your onboarding process.

--- a/specification/documentation/CreateMessageBatch.md
+++ b/specification/documentation/CreateMessageBatch.md
@@ -11,11 +11,9 @@ You must provide two reference values within the payload to this endpoint:
 
 Both of these references must be a [Universal Unique Identifier (UUID)](https://en.wikipedia.org/wiki/Universally_unique_identifier).
 
-The message batch reference (`messageBatchReference`) is unique for you. If you send the same message batch reference multiple times we will automatically deduplicate the requests - actioning only the first payload that has been sent. This value is used to store your reference for this batch of messages.
+The message batch reference (`messageBatchReference`) is unique for you. This value is used to store your reference for this batch of messages.
 
 The per message reference (`messageReference`) needs to be unique within the message batch. This value is used to store your reference for this specific message within the batch.
-
-If you send through a request with the same `messageBatchReference` on it then the system will respond with the same response as the first time the batch of messages was created.
 
 ### Personalisation
 


### PR DESCRIPTION
## Summary

Removing references to deduplicating requests from single message and batch message endpoints ahead of possible breaking change

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [x] Tester approval
