### PR TITLE
CCM-6416: fix broken import in e2e

### DIFF
--- a/tests/integration/messages/create_messages/test_field_validation.py
+++ b/tests/integration/messages/create_messages/test_field_validation.py
@@ -2,7 +2,7 @@ import requests
 import pytest
 import uuid
 from lib import Assertions, Permutations, Generators
-from lib.constants.constants import ERROR_TOO_FEW_ADDRESS_LINES, INT_URL, INVALID_NHS_NUMBER, INVALID_DOB, \
+from lib.constants.constants import GLOBAL_ROUTING_CONFIGURATION_SMS, INT_URL, INVALID_NHS_NUMBER, INVALID_DOB, \
     INVALID_PERSONALISATION_VALUES, NULL_VALUES, CORRELATION_IDS
 from lib.constants.messages_paths import MISSING_PROPERTIES_PATHS, NULL_PROPERTIES_PATHS, \
     INVALID_PROPERTIES_PATHS, MESSAGES_ENDPOINT
@@ -272,7 +272,7 @@ def test_too_large_personalisation(bearer_token_int):
     .. include:: ../../partials/validation/test_too_large_personalisation.rst
     """
     data = Generators.generate_valid_create_message_body("int")
-    data["data"]["attributes"]["routingPlanId"] = constants.GLOBAL_ROUTING_CONFIGURATION_SMS
+    data["data"]["attributes"]["routingPlanId"] = GLOBAL_ROUTING_CONFIGURATION_SMS
     data["data"]["attributes"]["personalisation"] = {
         'sms_body': 'x'*919
     }


### PR DESCRIPTION
## Summary

Fixes broken import in test file which is causing e2e to fail on int - blocking promotion of the release to prod

Following the [APIM patching steps](https://nhsd-confluence.digital.nhs.uk/display/RIS/Patching+Steps)

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
