### PR TITLE
CCM-7717: Fix channel status callback enum

### DIFF
--- a/specification/schemas/components/SupplierStatus.yaml
+++ b/specification/schemas/components/SupplierStatus.yaml
@@ -21,6 +21,9 @@ properties:
         type: string
         enum:
           - nhsapp
+          - sms
+          - letter
+          - email
         example: nhsapp
       channelStatus:
         $ref: ../enums/ChannelStatus.yaml


### PR DESCRIPTION
## Summary
`channel` enum in Channel Status callback only lists `nhsapp` but should include `nhsapp, sms, letter, email`


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
