### PR TITLE
CCM-7019: Set rate limit to 1800 TPS for ref and ref2

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -21,8 +21,17 @@ APIGEE_ENVIRONMENTS:
     variants:
     - name: ref
       display_name: Reference
+      app_ratelimit: '108000pm'
+      app_quota: '108000'
+      global_ratelimit: '108000pm'
+      global_quota: '108000'
     - name: 2-ref
       display_name: Reference - 2
+      display_name: Reference
+      app_ratelimit: '108000pm'
+      app_quota: '108000'
+      global_ratelimit: '108000pm'
+      global_quota: '108000'
   - name: internal-dev-sandbox
     variants:
     - name: internal-dev-sandbox


### PR DESCRIPTION
## Summary

Update ref and ref2 to allow up to 1800 transactions per second.
- Quota: set to 1800 * 60 = 108000 transactions per minute
- Rate limit: also set to 108000 to allow for 1800 TPS. The unit of this parameter is TPM but it's applied to seconds, see https://nhsd-confluence.digital.nhs.uk/display/APM/Rate+limiting+shared+flow for more info.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
