### PR TITLE
CCM-7948: Break out mTLS pipeline to dev and prod, update tests to assert generic exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,10 +192,15 @@ integration-test: .run-postman-int .integration-test
 
 production-test: .production-test
 
-mtls-test:
+mtls-test-dev:
 	$(TEST_CMD) \
 	tests/mtls \
-	-m mtlstest
+	-m "mtlstest and devtest or uattest"
+
+mtls-test-prod:
+	$(TEST_CMD) \
+	tests/mtls \
+	-m "mtlstest and inttest or prodtest"
 
 e2e-test-internal-dev:
 	$(TEST_CMD) \

--- a/azure/periodic-mtls-dev-pipeline.yml
+++ b/azure/periodic-mtls-dev-pipeline.yml
@@ -30,15 +30,15 @@ steps:
 # Set up the teams alert webhook
   - template: ./templates/teams-alert-setup.yml
     parameters:
-      webhook_uri: 'ALERTS_PROD_API_WEBHOOK_URI'
+      webhook_uri: 'ALERTS_DEV_API_WEBHOOK_URI'
 
 # Executes the tests
   - bash: |
-      make install-python && make mtls-test
+      make install-python && make mtls-test-dev
     timeoutInMinutes: 2
 
 # If the test run did not succeed posts an alert to teams
   - template: ./templates/teams-alert.yml
     parameters:
-      title: 'mTLS'
-      webhook_uri: 'ALERTS_PROD_API_WEBHOOK_URI'
+      title: 'mTLS Dev'
+      webhook_uri: 'ALERTS_DEV_API_WEBHOOK_URI'

--- a/azure/periodic-mtls-prod-pipeline.yml
+++ b/azure/periodic-mtls-prod-pipeline.yml
@@ -1,0 +1,44 @@
+name: "$(SourceBranchName)+$(BuildID)"
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+    - repository: common
+      type: github
+      name: NHSDigital/api-management-utils
+      ref: refs/heads/edge
+      endpoint: NHSDigital
+
+schedules:
+  - cron: '*/10 * * * *'
+    displayName: every 10 minutes
+    branches:
+      include: ['release']
+    always: true
+
+pool:
+  name: 'AWS-ECS'
+
+variables:
+  - template: project.yml
+  - name: SERVICE_ARTIFACT_NAME
+    value: ''
+
+steps:
+# Set up the teams alert webhook
+  - template: ./templates/teams-alert-setup.yml
+    parameters:
+      webhook_uri: 'ALERTS_PROD_API_WEBHOOK_URI'
+
+# Executes the tests
+  - bash: |
+      make install-python && make mtls-test-prod
+    timeoutInMinutes: 2
+
+# If the test run did not succeed posts an alert to teams
+  - template: ./templates/teams-alert.yml
+    parameters:
+      title: 'mTLS Prod'
+      webhook_uri: 'ALERTS_PROD_API_WEBHOOK_URI'

--- a/azure/templates/teams-alert.yml
+++ b/azure/templates/teams-alert.yml
@@ -12,6 +12,6 @@ steps:
 
       curl -g -v POST $TEAMS_WEBHOOK_URI \
       -H 'Content-Type: application/json' \
-      -d '{"@type": "MessageCard","@context": "http://schema.org/extensions","themeColor": "ff0000","title": "Nightly ${{parameters.title}} Test Run Failed","potentialAction":[{"@type": "OpenUri","name":"View Build","targets":[{"os": "default","uri": "https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId='$(build.buildid)'&view=results"}]}],"text": "The Nightly ${{parameters.title}} Test Run has failed, investigate and review if an action is required to correct the issue."}'
+      -d '{"@type": "MessageCard","@context": "http://schema.org/extensions","themeColor": "ff0000","title": "${{parameters.title}} Test Failure","potentialAction":[{"@type": "OpenUri","name":"View Build","targets":[{"os": "default","uri": "https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId='$(build.buildid)'&view=results"}]}],"text": "${{parameters.title}} tests have failed, investigate and review if an action is required to correct the issue."}'
     displayName: Post to Teams
     condition: ne(variables['Agent.JobStatus'], 'Succeeded')

--- a/tests/mtls/test_mtls.py
+++ b/tests/mtls/test_mtls.py
@@ -29,7 +29,7 @@ def test_mtls_connection_reset_by_peer_int():
     """
     with pytest.raises(Exception) as e:
         requests.get(INT_API_GATEWAY_URL, headers={"X-Client-Id": "hello"})
-    assert "Connection reset by peer" in str(e.value)
+    assert e.value is not None
 
 
 @pytest.mark.mtlstest
@@ -40,7 +40,7 @@ def test_mtls_connection_reset_by_peer_dev():
     """
     with pytest.raises(Exception) as e:
         requests.get(DEV_API_GATEWAY_URL, headers={"X-Client-Id": "hello"})
-    assert "Connection reset by peer" in str(e.value)
+    assert e.value is not None
 
 
 @pytest.mark.mtlstest
@@ -51,7 +51,7 @@ def test_mtls_connection_reset_by_peer_prod():
     """
     with pytest.raises(Exception) as e:
         requests.get(PROD_API_GATEWAY_URL, headers={"X-Client-Id": "hello"})
-    assert "Connection reset by peer" in str(e.value)
+    assert e.value is not None
 
 
 @pytest.mark.mtlstest
@@ -62,4 +62,4 @@ def test_mtls_connection_reset_by_peer_uat():
     """
     with pytest.raises(Exception) as e:
         requests.get(UAT_API_GATEWAY_URL, headers={"X-Client-Id": "hello"})
-    assert "Connection reset by peer" in str(e.value)
+    assert e.value is not None


### PR DESCRIPTION
## Summary
The changes made in this PR:

- Create two new pipeline jobs that run on a 10 minute schedule for the dev environments (internal-dev, internal-qa) and prod environments (int, prod)
- Update the tests to assert that a general exception is raised, rather than a specific exception (connection reset by peer) and rename them to reflect updated functionality
- Altered the alerting message to remove references to the frequency they are ran, all existing tests will now report: "Environment Test Failure, Environment tests have failed, investigate and review..."
- After this PR has been merged the existing job can be deleted

New pipelines created for mTLS Dev and mTLS prod
![image](https://github.com/user-attachments/assets/269b9a6a-fe36-412a-879c-54bd889106b3)

[mTLS Dev ](https://dev.azure.com/NHSD-APIM/API%20Platform/_build?definitionId=691) failure alert
<img width="984" alt="image" src="https://github.com/user-attachments/assets/97749f50-3a2f-483d-b470-2aa1b49f2ea6" />

[mTLS Prod ](https://dev.azure.com/NHSD-APIM/API%20Platform/_build?definitionId=692) failure alert
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/329c8a0a-cdfe-4116-aa99-5a9770d0f98c" />

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
