### PR TITLE
CCM-8384: Amend NHS number validation

### DIFF
--- a/docs/tests/development/post_v1_message-batches/happy_path.md
+++ b/docs/tests/development/post_v1_message-batches/happy_path.md
@@ -3,6 +3,22 @@
 ## 201 - Success
 
 
+### Scenario: An API consumer creating a batch of messages with an undefined NHS number receives a 201 response
+
+**Given** the API consumer does not provide an NHS number for a recipient in their new message batch and the allowAnonymousPatient flag is set to true
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response is a 201 success
+<br/>
+
+**Asserts**
+- Response returns a 201 status code
+- Response contains routingPlanId
+- Response contains messageBatchReference
+- Response contains a messages array with expected message references and ids
+
+
 ### Scenario: An API consumer creating a batch of messages with a valid accept header receives a 201 response
 
 **Given** the API consumer provides a valid accept header when creating a batch of messages

--- a/docs/tests/development/post_v1_messages/happy_path.md
+++ b/docs/tests/development/post_v1_messages/happy_path.md
@@ -3,6 +3,21 @@
 These tests target the API endpoint POST /v1/messages testing successful responses when valid data is provided.
 
 
+## Scenario: An API consumer creating a message with an undefined NHS number receives a 201 response
+
+**Given** the API consumer does not provide an NHS number for the recipient in their new message and the allowAnonymousPatient flag is set to true
+<br/>
+**When** the request is submitted
+<br/>
+**Then** the response is a 201 success
+<br/>
+
+**Asserts**
+- Response returns a 201 status code
+- Response body matches expected result
+- Response contains correctly formatted link to new message URI
+
+
 ## Scenario: An API consumer creating a message with a valid accept header receives a 201 response
 
 **Given** the API consumer provides a valid accept header when creating a message

--- a/proxies/shared/resources/jsc/helpers/validationChecks.js
+++ b/proxies/shared/resources/jsc/helpers/validationChecks.js
@@ -73,17 +73,15 @@ const validateConstantString = (errors, fieldValue, fieldPointer, requiredValue)
     return true
 }
 const validateNhsNumber = (errors, fieldValue, fieldPointer) => {
-    if (isUndefined(fieldValue)) {
-        errors.push(missingError(fieldPointer));
-        return false
-    }
-    if (fieldValue === null) {
-        errors.push(nullError(fieldPointer));
-        return false
-    }
-    if (typeof fieldValue !== "string" || !isValidNhsNumber(fieldValue, nhsNumberRegex)) {
-        errors.push(invalidNhsNumberError(fieldPointer));
-        return false
+    if (!isUndefined(fieldValue)) {
+        if (fieldValue === null) {
+            errors.push(nullError(fieldPointer));
+            return false
+        }
+        if (typeof fieldValue !== "string" || !isValidNhsNumber(fieldValue, nhsNumberRegex)) {
+            errors.push(invalidNhsNumberError(fieldPointer));
+            return false
+        }
     }
     return true
 }

--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -995,7 +995,7 @@ describe("/api/v1/send", () => {
                 recipient: {
                   nhsNumber: "1",
                   contactDetails: {
-                    sms: "07700900002",
+                    sms: "11111111111",
                   },
                 },
               },
@@ -1384,12 +1384,12 @@ describe("/api/v1/send", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'lines': Invalid",
+        message: "Invalid recipient contact details. Field 'lines': Too many address lines were provided",
         errors: [
           {
             code: 'CM_INVALID_VALUE',
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
-            message: "Invalid",
+            message: "Too many address lines were provided",
             title: "Invalid value",
           },
         ],

--- a/sandbox/__test__/messages.spec.js
+++ b/sandbox/__test__/messages.spec.js
@@ -693,7 +693,7 @@ describe("/api/v1/messages", () => {
             recipient: {
               nhsNumber: "1",
               contactDetails: {
-                sms: "07700900002",
+                sms: "11111111111",
               },
             },
             personalisation: {},
@@ -1041,12 +1041,12 @@ describe("/api/v1/messages", () => {
         },
       })
       .expect(400, {
-        message: "Invalid recipient contact details. Field 'lines': Invalid",
+        message: "Invalid recipient contact details. Field 'lines': Too many address lines were provided",
         errors: [
           {
             code: 'CM_INVALID_VALUE',
             field: "/data/attributes/recipient/contactDetails/address",
-            message: "Invalid",
+            message: "Too many address lines were provided",
             title: "Invalid value",
           },
         ],

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -1,6 +1,6 @@
 import { notAllowedContactDetailOverride } from "../config.js";
 
-const invalidPhoneNumber = "07700900002";
+const invalidPhoneNumber = "11111111111";
 const invalidEmailAddress = "invalidEmailAddress";
 
 function validationSuccess() {
@@ -143,9 +143,9 @@ function addressValidation(address, path) {
         title: "Invalid value",
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/address`,
-        message: "Invalid",
+        message: "Too many address lines were provided",
       },
-      `Field 'lines': Invalid`,
+      `Field 'lines': Too many address lines were provided`,
     ]);
   }
 

--- a/specification/responses/4xx/message_batches/400_UnableToProcessMessageBatch.yaml
+++ b/specification/responses/4xx/message_batches/400_UnableToProcessMessageBatch.yaml
@@ -49,7 +49,7 @@ description: |+
 
   | Field | Value | Description |
   | ---------- | ----- | ----------- |
-  | sms | 07700900002 | Returns 'Input failed format check' error with a pointer to sms. |
+  | sms | 11111111111 | Returns 'Input failed format check' error with a pointer to sms. |
   | email | invalidEmailAddress | Returns 'Input failed format check' error with a pointer to email. |
 content:
   application/vnd.api+json:

--- a/specification/responses/4xx/messages/400_UnableToProcessMessage.yaml
+++ b/specification/responses/4xx/messages/400_UnableToProcessMessage.yaml
@@ -47,7 +47,7 @@ description: |+
 
   | Field | Value | Description |
   | ---------- | ----- | ----------- |
-  | sms | 07700900002 | Returns 'Input failed format check' error with a pointer to sms. |
+  | sms | 11111111111 | Returns 'Input failed format check' error with a pointer to sms. |
   | email | invalidEmailAddress | Returns 'Input failed format check' error with a pointer to email. |
 content:
   application/vnd.api+json:

--- a/tests/development/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/development/message_batches/create_message_batches/test_field_validation.py
@@ -668,7 +668,7 @@ def test_invalid_address_contact_details_too_many_lines(nhsd_apim_proxy_url, bea
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/messages/0/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/development/message_batches/create_message_batches/test_success.py
+++ b/tests/development/message_batches/create_message_batches/test_success.py
@@ -75,6 +75,29 @@ def test_201_message_batch_valid_nhs_number(
 
 
 @pytest.mark.devtest
+def test_201_message_batch_undefined_nhs_number(
+    nhsd_apim_proxy_url,
+    bearer_token_internal_dev
+):
+    """
+    .. include:: ../../partials/happy_path/test_201_message_batch_undefined_nhs_number.rst
+    """
+    data = Generators.generate_valid_create_message_batch_body("dev")
+    data["data"]["attributes"]["messages"][0]["recipient"].pop("nhsNumber", None)
+
+    resp = requests.post(
+        f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}",
+        headers={
+            "Authorization": bearer_token_internal_dev.value,
+            "Accept": constants.DEFAULT_CONTENT_TYPE,
+            "Content-Type": constants.DEFAULT_CONTENT_TYPE,
+        },
+        json=data,
+    )
+    Assertions.assert_201_response(resp, data)
+
+
+@pytest.mark.devtest
 def test_201_message_batch_valid_contact_details(
     nhsd_apim_proxy_url,
     bearer_token_internal_dev

--- a/tests/development/messages/create_messages/test_field_validation.py
+++ b/tests/development/messages/create_messages/test_field_validation.py
@@ -301,7 +301,7 @@ def test_invalid_sms_contact_details(nhsd_apim_proxy_url, bearer_token_internal_
     .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
     """
     data = Generators.generate_valid_create_message_body("dev")
-    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "07700900002"}
+    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "11111111111"}
     resp = requests.post(
         f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}",
         headers={

--- a/tests/development/messages/create_messages/test_field_validation.py
+++ b/tests/development/messages/create_messages/test_field_validation.py
@@ -414,7 +414,7 @@ def test_invalid_address_contact_details_too_many_lines(nhsd_apim_proxy_url, bea
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/development/messages/create_messages/test_success.py
+++ b/tests/development/messages/create_messages/test_success.py
@@ -60,6 +60,24 @@ def test_201_message_valid_nhs_number(nhsd_apim_proxy_url, bearer_token_internal
 
 
 @pytest.mark.devtest
+def test_201_message_undefined_nhs_number(nhsd_apim_proxy_url, bearer_token_internal_dev):
+    """
+    .. include:: ../../partials/happy_path/test_201_messages_undefined_nhs_number.rst
+    """
+    data = Generators.generate_valid_create_message_body("dev")
+    data["data"]["attributes"]["recipient"].pop("nhsNumber", None)
+
+    resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
+            "Authorization": bearer_token_internal_dev.value,
+            "Accept": constants.DEFAULT_CONTENT_TYPE,
+            "Content-Type": constants.DEFAULT_CONTENT_TYPE
+        }, json=data
+    )
+
+    Assertions.assert_201_response_messages(resp, nhsd_apim_proxy_url)
+
+
+@pytest.mark.devtest
 def test_201_message_valid_contact_details(nhsd_apim_proxy_url, bearer_token_internal_dev):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_contact_details.rst

--- a/tests/docs/partials/happy_path/test_201_message_batch_undefined_nhs_number.rst
+++ b/tests/docs/partials/happy_path/test_201_message_batch_undefined_nhs_number.rst
@@ -1,0 +1,12 @@
+Scenario: An API consumer creating a batch of messages with an undefined NHS number receives a 201 response
+===========================================================================================================
+
+| **Given** the API consumer does not provide an NHS number for a recipient in their new message batch and the allowAnonymousPatient flag is set to true
+| **When** the request is submitted
+| **Then** the response is a 201 success
+
+**Asserts**
+- Response returns a 201 status code
+- Response contains routingPlanId
+- Response contains messageBatchReference
+- Response contains a messages array with expected message references and ids

--- a/tests/docs/partials/happy_path/test_201_messages_undefined_nhs_number.rst
+++ b/tests/docs/partials/happy_path/test_201_messages_undefined_nhs_number.rst
@@ -1,0 +1,11 @@
+Scenario: An API consumer creating a message with an undefined NHS number receives a 201 response
+==================================================================================================
+
+| **Given** the API consumer does not provide an NHS number for the recipient in their new message and the allowAnonymousPatient flag is set to true
+| **When** the request is submitted
+| **Then** the response is a 201 success
+
+**Asserts**
+- Response returns a 201 status code
+- Response body matches expected result
+- Response contains correctly formatted link to new message URI

--- a/tests/integration/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/integration/message_batches/create_message_batches/test_field_validation.py
@@ -560,7 +560,7 @@ def test_invalid_address_contact_details_too_many_lines(bearer_token_int, correl
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/messages/0/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/integration/messages/create_messages/test_field_validation.py
+++ b/tests/integration/messages/create_messages/test_field_validation.py
@@ -302,7 +302,7 @@ def test_invalid_sms_contact_details(bearer_token_int, correlation_id):
     .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
     """
     data = Generators.generate_valid_create_message_body("int")
-    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "07700900002"}
+    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "11111111111"}
     resp = requests.post(
         f"{INT_URL}{MESSAGES_ENDPOINT}",
         headers={
@@ -415,7 +415,7 @@ def test_invalid_address_contact_details_too_many_lines(bearer_token_int, correl
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/lib/constants/message_batches_paths.py
+++ b/tests/lib/constants/message_batches_paths.py
@@ -16,7 +16,6 @@ MISSING_PROPERTIES_PATHS = [
     ("messages", MESSAGES_PATH),
     ("messageReference", FIRST_MESSAGE_REFERENCE_PATH),
     ("recipient", FIRST_MESSAGE_RECIPIENT_PATH),
-    ("nhsNumber", FIRST_MESSAGE_RECIPIENT_NHSNUMBER_PATH),
 ]
 NULL_PROPERTIES_PATHS = [
     ("data", "/data"),

--- a/tests/lib/constants/messages_paths.py
+++ b/tests/lib/constants/messages_paths.py
@@ -14,7 +14,6 @@ MISSING_PROPERTIES_PATHS = [
     ("routingPlanId", ROUTING_PLAN_ID_PATH),
     ("messageReference", MESSAGE_REFERENCE_PATH),
     ("recipient", MESSAGE_RECIPIENT_PATH),
-    ("nhsNumber", MESSAGE_RECIPIENT_NHSNUMBER_PATH),
 ]
 NULL_PROPERTIES_PATHS = [
     ("data", "/data"),

--- a/tests/production/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/production/message_batches/create_message_batches/test_field_validation.py
@@ -487,7 +487,7 @@ def test_invalid_address_contact_details_too_many_lines(bearer_token_prod, corre
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/messages/0/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/production/messages/create_messages/test_field_validation.py
+++ b/tests/production/messages/create_messages/test_field_validation.py
@@ -262,7 +262,7 @@ def test_invalid_sms_contact_details(bearer_token_prod, correlation_id):
     .. include:: ../../partials/validation/test_invalid_contact_details_sms.rst
     """
     data = Generators.generate_valid_create_message_body("prod")
-    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "07700900002"}
+    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "11111111111"}
     resp = requests.post(
         f"{constants.PROD_URL}{MESSAGES_ENDPOINT}",
         headers={
@@ -375,7 +375,7 @@ def test_invalid_address_contact_details_too_many_lines(bearer_token_prod, corre
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_field_validation.py
@@ -512,7 +512,7 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
     .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
     data = Generators.generate_valid_create_message_batch_body()
-    data["data"]["attributes"]["messages"][0]["recipient"]["contactDetails"] = {"sms": "07700900002"}
+    data["data"]["attributes"]["messages"][0]["recipient"]["contactDetails"] = {"sms": "11111111111"}
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGE_BATCHES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
@@ -554,7 +554,7 @@ def test_invalid_sms_contact_details(nhsd_apim_proxy_url, correlation_id):
                         "recipient": {
                             "nhsNumber": "9990548609",
                             "contactDetails": {
-                                "sms": "07700900002"
+                                "sms": "11111111111"
                             }
                         },
                     }
@@ -706,7 +706,7 @@ def test_invalid_address_contact_details_too_many_lines(nhsd_apim_proxy_url, cor
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/messages/0/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )

--- a/tests/sandbox/messages/create_messages/test_field_validation.py
+++ b/tests/sandbox/messages/create_messages/test_field_validation.py
@@ -296,7 +296,7 @@ def test_not_permitted_to_use_contact_details(nhsd_apim_proxy_url, correlation_i
     .. include:: ../../partials/validation/test_not_permitted_to_use_contact_details.rst
     """
     data = Generators.generate_valid_create_message_body()
-    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "07700900002"}
+    data["data"]["attributes"]["recipient"]["contactDetails"] = {"sms": "11111111111"}
     resp = requests.post(f"{nhsd_apim_proxy_url}{MESSAGES_ENDPOINT}", headers={
         **headers,
         "X-Correlation-Id": correlation_id,
@@ -334,7 +334,7 @@ def test_invalid_sms_contact_details(nhsd_apim_proxy_url, correlation_id):
                 "recipient": {
                     "nhsNumber": "9990548609",
                     "contactDetails": {
-                        "sms": "07700900002"
+                        "sms": "11111111111"
                     }
                 },
             }
@@ -469,7 +469,7 @@ def test_invalid_address_contact_details_too_many_lines(nhsd_apim_proxy_url, cor
         400,
         Generators.generate_invalid_value_error_custom_detail(
             "/data/attributes/recipient/contactDetails/address",
-            "Invalid"
+            "Too many address lines were provided"
         ),
         correlation_id
     )


### PR DESCRIPTION
## Summary
Amend NHS number validation so that if the NHS number is undefined it returns true for anonymous patients feature.

Note: as part of this work, the AWS APIM integration test client was changed to add "allowAnonymousPatient":true

## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [x] Tester approval
