### PR TITLE
CCM-8891: Add allow international sms numbers tests

### DIFF
--- a/tests/development/message_batches/create_message_batches/test_success.py
+++ b/tests/development/message_batches/create_message_batches/test_success.py
@@ -98,9 +98,11 @@ def test_201_message_batch_undefined_nhs_number(
 
 
 @pytest.mark.devtest
+@pytest.mark.parametrize('valid_sms_numbers', constants.VALID_SMS_NUMBERS)
 def test_201_message_batch_valid_contact_details(
     nhsd_apim_proxy_url,
-    bearer_token_internal_dev
+    bearer_token_internal_dev,
+    valid_sms_numbers
 ):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_contact_details.rst
@@ -112,7 +114,7 @@ def test_201_message_batch_valid_contact_details(
     data["data"]["attributes"]["messages"][0]["recipient"][
         "contactDetails"
     ] = {
-        "sms": "07777777777",
+        "sms": valid_sms_numbers,
         "email": "ab@cd.co.uk",
         "address": {
             "lines": ["Line 1", "Line 2"],

--- a/tests/development/messages/create_messages/test_success.py
+++ b/tests/development/messages/create_messages/test_success.py
@@ -78,14 +78,15 @@ def test_201_message_undefined_nhs_number(nhsd_apim_proxy_url, bearer_token_inte
 
 
 @pytest.mark.devtest
-def test_201_message_valid_contact_details(nhsd_apim_proxy_url, bearer_token_internal_dev):
+@pytest.mark.parametrize('valid_sms_numbers', constants.VALID_SMS_NUMBERS)
+def test_201_message_valid_contact_details(nhsd_apim_proxy_url, bearer_token_internal_dev, valid_sms_numbers):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_contact_details.rst
     """
     data = Generators.generate_valid_create_message_body("dev")
     data["data"]["attributes"]["recipient"]["nhsNumber"] = constants.VALID_NHS_NUMBER
     data["data"]["attributes"]["recipient"]["contactDetails"] = {
-        "sms": "07777777777",
+        "sms": valid_sms_numbers,
         "email": "ab@cd.co.uk",
         "address": {
             "lines": ["Line 1", "Line 2"],

--- a/tests/integration/message_batches/create_message_batches/test_success.py
+++ b/tests/integration/message_batches/create_message_batches/test_success.py
@@ -67,8 +67,10 @@ def test_201_message_batch_valid_nhs_number(bearer_token_int):
 
 
 @pytest.mark.inttest
+@pytest.mark.parametrize('valid_sms_numbers', constants.VALID_SMS_NUMBERS)
 def test_201_message_batch_valid_contact_details(
-    bearer_token_int
+    bearer_token_int,
+    valid_sms_numbers
 ):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_contact_details.rst
@@ -80,7 +82,7 @@ def test_201_message_batch_valid_contact_details(
     data["data"]["attributes"]["messages"][0]["recipient"][
         "contactDetails"
     ] = {
-        "sms": "07777777777",
+        "sms": valid_sms_numbers,
         "email": "ab@cd.co.uk",
         "address": {
             "lines": ["Line 1", "Line 2"],

--- a/tests/integration/messages/create_messages/test_success.py
+++ b/tests/integration/messages/create_messages/test_success.py
@@ -3,7 +3,7 @@ import pytest
 import time
 from lib import Assertions, Generators
 from lib.constants.constants import DEFAULT_CONTENT_TYPE, INT_URL, VALID_CONTENT_TYPE_HEADERS, VALID_ACCEPT_HEADERS, \
-    VALID_NHS_NUMBER, VALID_ROUTING_PLAN_ID_INT
+    VALID_NHS_NUMBER, VALID_SMS_NUMBERS
 from lib.constants.messages_paths import MESSAGES_ENDPOINT
 from lib.fixtures import *  # NOSONAR
 
@@ -61,14 +61,15 @@ def test_201_single_message_with_valid_nhs_number(bearer_token_int):
 
 
 @pytest.mark.inttest
-def test_201_message_valid_contact_details(bearer_token_int):
+@pytest.mark.parametrize('valid_sms_numbers', VALID_SMS_NUMBERS)
+def test_201_message_valid_contact_details(bearer_token_int, valid_sms_numbers):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_contact_details.rst
     """
     data = Generators.generate_valid_create_message_body("int")
     data["data"]["attributes"]["recipient"]["nhsNumber"] = VALID_NHS_NUMBER
     data["data"]["attributes"]["recipient"]["contactDetails"] = {
-        "sms": "07777777777",
+        "sms": valid_sms_numbers,
         "email": "ab@cd.co.uk",
         "address": {
             "lines": ["Line 1", "Line 2"],

--- a/tests/lib/constants/constants.py
+++ b/tests/lib/constants/constants.py
@@ -49,6 +49,13 @@ VALID_ACCEPT_HEADERS = ["*/*", DEFAULT_CONTENT_TYPE]
 VALID_CONTENT_TYPE_HEADERS = [DEFAULT_CONTENT_TYPE]
 
 INVALID_MESSAGE_VALUES = ["", [], 5, 0.1]
+VALID_SMS_NUMBERS = [
+      '+7 (8) (495) 123-45-67',
+      '007 (8) (495) 123-45-67',
+      '+33122334455',
+      '07723456789',
+      '+447723456789',
+    ]
 
 INVALID_NHS_NUMBER = ["999054860", "99905486090", "abcdefghij", "", [], {}, 5, 0.1]
 # Set to PDS production smoke test user

--- a/tests/sandbox/message_batches/create_message_batches/test_success.py
+++ b/tests/sandbox/message_batches/create_message_batches/test_success.py
@@ -81,7 +81,8 @@ def test_201_message_batch_valid_nhs_number(nhsd_apim_proxy_url):
 
 
 @pytest.mark.sandboxtest
-def test_201_message_batch_valid_contact_details(nhsd_apim_proxy_url):
+@pytest.mark.parametrize('valid_sms_numbers', constants.VALID_SMS_NUMBERS)
+def test_201_message_batch_valid_contact_details(nhsd_apim_proxy_url, valid_sms_numbers):
     """
     .. include:: ../../partials/happy_path/test_201_message_batch_valid_contact_details.rst
     """
@@ -92,7 +93,7 @@ def test_201_message_batch_valid_contact_details(nhsd_apim_proxy_url):
     data["data"]["attributes"]["messages"][0]["recipient"][
         "contactDetails"
     ] = {
-        "sms": "07777777777",
+        "sms": valid_sms_numbers,
         "email": "ab@cd.co.uk",
         "address": {
             "lines": ["Line 1", "Line 2"],

--- a/tests/sandbox/messages/create_messages/test_success.py
+++ b/tests/sandbox/messages/create_messages/test_success.py
@@ -63,14 +63,15 @@ def test_201_single_message_with_valid_nhs_number(nhsd_apim_proxy_url):
 
 
 @pytest.mark.sandboxtest
-def test_201_single_message_with_valid_contact_details(nhsd_apim_proxy_url):
+@pytest.mark.parametrize('valid_sms_numbers', constants.VALID_SMS_NUMBERS)
+def test_201_single_message_with_valid_contact_details(nhsd_apim_proxy_url, valid_sms_numbers):
     """
     .. include:: ../../partials/happy_path/test_201_messages_valid_contact_details.rst
     """
     data = Generators.generate_valid_create_message_body("sandbox")
     data["data"]["attributes"]["recipient"]["nhsNumber"] = constants.VALID_NHS_NUMBER
     data["data"]["attributes"]["recipient"]["contactDetails"] = {
-        "sms": "07777777777",
+        "sms": valid_sms_numbers,
         "email": "ab@cd.co.uk",
         "address": {
             "lines": ["Line 1", "Line 2"],


### PR DESCRIPTION
## Summary
This PR adds tests to verify that sms contact detail override accepts international numbers.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [x] Tester approval
