### PR TITLE
CCM-8270: Aggregate error items

### DIFF
--- a/proxies/shared/partials/Partial.Target.FaultRules.xml
+++ b/proxies/shared/partials/Partial.Target.FaultRules.xml
@@ -70,7 +70,7 @@
     </Step>
     <Step>
         <Name>RaiseFault.404NotFound</Name>
-        <Condition>response.status.code = 404</Condition>
+        <Condition>response.status.code = 404 and data.errors == null</Condition>
     </Step>
     <Step>
         <Name>RaiseFault.413RequestTooLarge</Name>

--- a/proxies/shared/resources/jsc/EnhanceErrorDetails.js
+++ b/proxies/shared/resources/jsc/EnhanceErrorDetails.js
@@ -1,6 +1,5 @@
 const errors = context.getVariable('data.errors');
 const messageId = context.getVariable('messageid');
-const statusCode = context.getVariable('response.status.code');
 const links = {
     about: "{{ ERROR_ABOUT_LINK }}"
 };
@@ -8,17 +7,21 @@ const links = {
 const enhancedErrors = [];
 
 JSON.parse(errors).forEach((error, index) => {
-    enhancedErrors.push({
+    var translatedError = {
         id: messageId + '.' + index,
         code: error.code,
         links: links,
-        status: String(statusCode),
+        status: String(error.statusCode),
         title: error.title,
-        detail: error.message,
-        source: {
+        detail: error.message
+    };
+    if (error.field) {
+        translatedError.source = {
             pointer: error.field
-        }
-    });
+        };
+    }
+
+    enhancedErrors.push(translatedError);
 });
 
 context.setVariable("error.content", JSON.stringify({ errors: enhancedErrors }));

--- a/sandbox/__test__/batch_send.spec.js
+++ b/sandbox/__test__/batch_send.spec.js
@@ -945,6 +945,7 @@ describe("/api/v1/send", () => {
             field: `/data/attributes/messages/0/recipient/contactDetails`,
             message:
               'Client is not allowed to provide alternative contact details.',
+            statusCode: 400,
           },
         ],
       })
@@ -1012,6 +1013,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/sms",
             message: "Input failed format check",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1052,6 +1054,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/sms",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1119,6 +1122,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/email",
             message: "Input failed format check",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1159,6 +1163,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/email",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1228,6 +1233,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1266,6 +1272,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1308,6 +1315,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "`lines` is missing",
             title: "Missing value",
+            statusCode: 400,
           },
         ],
       })
@@ -1349,7 +1357,8 @@ describe("/api/v1/send", () => {
             code: 'CM_TOO_FEW_ITEMS',
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Too few items"
+            title: "Too few items",
+            statusCode: 400,
           }
         ]
       })
@@ -1391,6 +1400,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Too many address lines were provided",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1432,6 +1442,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1473,6 +1484,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "`postcode` is missing",
             title: "Missing value",
+            statusCode: 400,
           },
         ],
       })
@@ -1514,6 +1526,7 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/address/postcode",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1556,12 +1569,14 @@ describe("/api/v1/send", () => {
             field: "/data/attributes/messages/0/recipient/contactDetails/email",
             message: "Input failed format check",
             title: "Invalid value",
+            statusCode: 400,
           },
           {
             code: 'CM_TOO_FEW_ITEMS',
             field: "/data/attributes/messages/0/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Too few items"
+            title: "Too few items",
+            statusCode: 400,
           },
         ],
       })

--- a/sandbox/__test__/messages.spec.js
+++ b/sandbox/__test__/messages.spec.js
@@ -650,6 +650,7 @@ describe("/api/v1/messages", () => {
             field: `/data/attributes/recipient/contactDetails`,
             message:
               'Client is not allowed to provide alternative contact details.',
+            statusCode: 400,
           },
         ],
       })
@@ -709,6 +710,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/sms",
             message: "Input failed format check",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -745,6 +747,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/sms",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -804,6 +807,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/email",
             message: "Input failed format check",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -840,6 +844,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/email",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -901,6 +906,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -935,6 +941,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -973,6 +980,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "`lines` is missing",
             title: "Missing value",
+            statusCode: 400,
           },
         ],
       })
@@ -1010,7 +1018,8 @@ describe("/api/v1/messages", () => {
             code: 'CM_TOO_FEW_ITEMS',
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Too few items"
+            title: "Too few items",
+            statusCode: 400,
           }
         ]
       })
@@ -1048,6 +1057,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Too many address lines were provided",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1085,6 +1095,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1122,6 +1133,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address",
             message: "`postcode` is missing",
             title: "Missing value",
+            statusCode: 400,
           },
         ],
       })
@@ -1159,6 +1171,7 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/address/postcode",
             message: "Invalid",
             title: "Invalid value",
+            statusCode: 400,
           },
         ],
       })
@@ -1197,12 +1210,14 @@ describe("/api/v1/messages", () => {
             field: "/data/attributes/recipient/contactDetails/email",
             message: "Input failed format check",
             title: "Invalid value",
+            statusCode: 400,
           },
           {
             code: 'CM_TOO_FEW_ITEMS',
             field: "/data/attributes/recipient/contactDetails/address",
             message: "Too few address lines were provided",
-            title: "Too few items"
+            title: "Too few items",
+            statusCode: 400,
           },
         ],
       })

--- a/sandbox/handlers/error_scenarios/override_contact_details.js
+++ b/sandbox/handlers/error_scenarios/override_contact_details.js
@@ -27,6 +27,7 @@ function smsValidation(sms, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/sms`,
         message: "Input failed format check",
+        statusCode: 400,
       },
       `Field 'sms': Input failed format check`,
     ]);
@@ -38,6 +39,7 @@ function smsValidation(sms, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/sms`,
         message: "Invalid",
+        statusCode: 400,
       },
       `Field 'sms': Invalid`,
     ]);
@@ -56,6 +58,7 @@ function emailValidation(email, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/email`,
         message: "Input failed format check",
+        statusCode: 400,
       },
       `Field 'email': Input failed format check`,
     ]);
@@ -67,6 +70,7 @@ function emailValidation(email, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/email`,
         message: "Invalid",
+        statusCode: 400,
       },
       `Field 'email': Invalid`,
     ]);
@@ -86,6 +90,7 @@ function addressValidation(address, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/address`,
         message: "Invalid",
+        statusCode: 400,
       },
       `Field 'address': Invalid`,
     ]);
@@ -98,6 +103,7 @@ function addressValidation(address, path) {
         code: 'CM_MISSING_VALUE',
         field: `${path}/recipient/contactDetails/address`,
         message: "`lines` is missing",
+        statusCode: 400,
       },
       `Field 'lines': 'lines' is missing`,
     ]);
@@ -109,6 +115,7 @@ function addressValidation(address, path) {
         code: 'CM_MISSING_VALUE',
         field: `${path}/recipient/contactDetails/address`,
         message: "`lines` is missing",
+        statusCode: 400,
       },
       `Field 'lines': 'lines' is missing`,
     ]);
@@ -121,6 +128,7 @@ function addressValidation(address, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/address`,
         message: "Invalid",
+        statusCode: 400,
       },
       `Field 'lines': Invalid`,
     ]);
@@ -133,6 +141,7 @@ function addressValidation(address, path) {
         title: "Too few items",
         field: `${path}/recipient/contactDetails/address`,
         message: "Too few address lines were provided",
+        statusCode: 400,
       },
       `Field 'lines': Too few address lines were provided`,
     ]);
@@ -144,6 +153,7 @@ function addressValidation(address, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/address`,
         message: "Too many address lines were provided",
+        statusCode: 400,
       },
       `Field 'lines': Too many address lines were provided`,
     ]);
@@ -156,6 +166,7 @@ function addressValidation(address, path) {
         code: 'CM_MISSING_VALUE',
         field: `${path}/recipient/contactDetails/address`,
         message: "`postcode` is missing",
+        statusCode: 400,
       },
       `Field 'postcode': 'postcode' is missing`,
     ]);
@@ -168,6 +179,7 @@ function addressValidation(address, path) {
         code: 'CM_INVALID_VALUE',
         field: `${path}/recipient/contactDetails/address/postcode`,
         message: "Invalid",
+        statusCode: 400,
       },
       `Field 'postcode': Invalid`,
     ]);
@@ -194,6 +206,7 @@ export function getAlternateContactDetailsError(
           title: "Cannot set contact details",
           field: `${path}/recipient/contactDetails`,
           message: "Client is not allowed to provide alternative contact details.",
+          statusCode: 400,
         },
       ]
     ];


### PR DESCRIPTION
## Summary
This is a minor change to accommodate this BE PR: https://github.com/NHSDigital/comms-mgr/pull/515 in order to:
- Use the status code returned by the BE for each error item
- Not populate the source on an error item when it's not provided by the BE
- Allow the BE to return 404 errors and translate them instead of just returning a generic error

Note that the internal-dev tests can only pass with the new BE.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [x] Tester approval
