### PR TITLE
CCM-8596: Update Message and Channel Status Callback docs

### DIFF
--- a/specification/callbacks/channel_status.yaml
+++ b/specification/callbacks/channel_status.yaml
@@ -1,13 +1,28 @@
 
-summary: Channel status
+summary: Channel and supplier status
 description: |-
+  The channel and supplier status callback sends POST requests to your service with real time updates when the status of a channel or supplier has changed.
 
-    NHS Notify can send a channel status callback when:
-    * the channel status has changed - This refers to the internal statuses used by NHS Notify, which are consistent across all channels
-    * the supplier status has changed - This is the raw status value specified by the underlying channel supplier. The possible values are listed [here](#overview--supplier-statuses)
+  This is an automated way to get the status of each channel used in a routing plan.
+  
+  <a href="https://notify.nhs.uk/using-nhs-notify/message-channel-supplier-status#channel-and-supplier-status" target="_new">Find out more about channel statuses and which statuses you can receive (opens in a new tab)</a>.
 
-    The specific state transitions that trigger a callback will be agreed as part of onboarding in order to minimise unnecessary traffic.
+  For more detailed statuses about specific channels, you can also receive supplier statuses.
 
+  <a href="https://notify.nhs.uk/using-nhs-notify/message-channel-supplier-status#supplier-status-descriptions" target="_new">Find out more about supplier statuses and and which statuses you can receive (opens in a new tab)</a>.
+
+  If you're onboarding with NHS Notify and need to use the channel and supplier status callback, contact the onboarding team to tell them what statuses you want to subscribe to.
+
+  If you're live with NHS Notify and need to use the channel and supplier status callback, [raise a Service Now ticket](https://nhsdigitallive.service-now.com/csm).
+
+  ### Deciding which message status callbacks to receive
+  It's your organisation or service's responsibility to decide which statuses to receive callbacks for.
+
+  You may need to subscribe to a combination of channel and supplier statuses if you:
+
+  - want to send your own fallback messages based on specific statuses
+  - need to know exactly how a message has performed in real time with each of your recipients
+  - need to know what happened to a message sent using a <a href="https://notify.nhs.uk/using-nhs-notify/routing-plans#secondary-cascades" target="_new">secondary cascade (opens in a new tab)
 operationId: post-v1-channel-callbacks
 parameters:
     - name: x-hmac-sha256-signature

--- a/specification/callbacks/message_status.yaml
+++ b/specification/callbacks/message_status.yaml
@@ -2,16 +2,25 @@
 summary: Message status
 description: |-
     
-    NHS Notify will send a callback when the message status is updated to any of the following (message statuses are only updated for primary channels):
+    Message status callbacks send POST requests to your service with real time updates when the status of a message has changed.
 
-    * `delivered` - the message has been delivered (via any channel)
-    * `failed` - the message could not be delivered by any channel
+    This is an automated way to get the status of messages.
 
-    Callbacks can be received for additional state transitions subject to the needs of the user. These additional state transitions can be requested during onboarding. These statuses are:
+    <a href="https://notify.nhs.uk/using-nhs-notify/message-channel-supplier-status" target="_new">Find out more about message statuses and which statuses you can receive (opens in a new tab)</a>.
 
-    * `pending_enrichment` - the message is currently pending enrichment
-    * `enriched` - NHS Notify has queried PDS for this patient's details and now know how to contact this individual
-    * `sending` - the message is in the process of being sent - this can occur multiple times for a single message if multiple channels are to be attempted
+    If you're onboarding with NHS Notify and need to use the channel and supplier status callback, contact the onboarding team to tell them what statuses you want to subscribe to.
+
+    If you're live with NHS Notify and need to use the channel and supplier status callback, [raise a Service Now ticket](https://nhsdigitallive.service-now.com/csm).
+
+    ### Deciding which message status callbacks to receive
+
+    It's your organisation or service's responsibility to decide which statuses to receive callbacks for.
+    
+    The message status callbacks are typically used for finding out if a recipient has been contacted with any of the channels in a routing plan.
+    
+    For example, if you only want updating when your patients have been contacted and do not need updating when each message channel was used, choose the `delivered` and `failed` message statuses.
+    
+    If you need additional real time updates when the status of a channel changes, you can also use the channel and supplier status callback.
 operationId: post-v1-message-callbacks
 parameters:
     - name: x-hmac-sha256-signature

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -146,7 +146,7 @@ Free-text communications (as opposed to fixed format communications) are possibl
 | 00000000-0000-0000-0000-000000000002 | Email            |                                         | email_body, email_subject  |
 | 00000000-0000-0000-0000-000000000003 | SMS              |                                         | sms_body                   |
 
-Please see the Postman collections in the [environments and testing section](#section/Environments-and-testing) for examples.
+Please see the Postman collections in the [environments and testing section](#overview--environments-and-testing) for examples.
 
 ## Errors
 
@@ -185,57 +185,3 @@ Different character limits apply to each of the communication channels as listed
 | Letter             | 15,000          |
 | NHS App            | 5,000           |
 | Text message (SMS) | 918             |
-
-## Message statuses
-
-Messages can have the following statuses:
-
-* `created` - the message has been created, but has received no processing
-* `pending_enrichment` - the message is currently pending enrichment
-* `enriched` - we have queried PDS for this patient's details and now know how to contact this individual
-* `sending` - the message is in the process of being sent
-* `delivered` - the message has been delivered
-* `failed` - we have failed to deliver the message
-
-For certain statuses more information can be found within the `messageStatusDescription` field.
-
-The message status shows an overall aggregate status taken from all of the communication channels that we have attempted to deliver the message using.
-
-## Supplier statuses
-
-The channels can have the following supplier statuses:
-
-### NHS App
-
-* `delivered` - the message has been successfully delivered to the user
-* `read` - a user has read the message
-* `notification_attempted` - a push notification is reported as having been sent to one or more devices, but does not indicate whether the notification was received or displayed
-* `unnotified` - it has been determined that a push notification has not been successfully relayed to any devices
-* `rejected` - the request to send the communication was rejected by the supplier
-* `notified` - a push notification is reported as having been successfully relayed to one or more devices
-* `received` - the request has been received by the supplier and is queued to be processed
-
-### Email
-
-* `delivered` - the message has been successfully delivered to the user
-* `permanent_failure` - the Email/SMS provider could not deliver the message, this can happen if the phone number was wrong or if the network operator rejects the message
-* `temporary_failure` - the Email/SMS provider could not deliver the message, this can happen when the recipient's phone is off, has no signal, or their text message inbox is full
-* `technical_failure` - the message was not sent because there was a problem between GOV.UK Notify and the Email/SMS provider
-
-### SMS
-
-* `delivered` - the message has been successfully delivered to the user
-* `permanent_failure` - the Email/SMS provider could not deliver the message, this can happen if the phone number was wrong or if the network operator rejects the message
-* `temporary_failure` - the Email/SMS provider could not deliver the message, this can happen when the recipient's phone is off, has no signal, or their text message inbox is full
-* `technical_failure` - the message was not sent because there was a problem between GOV.UK Notify and the Email/SMS provider
-
-### Letters
-
-* `accepted` - GOV.UK Notify has sent the letter to the provider to be printed
-* `received` - the provider has printed and dispatched the letter
-* `cancelled` - sending cancelled, the letter will not be printed or dispatched
-* `pending_virus_check` - GOV.UK Notify has not completed a virus scan of the precompiled letter file
-* `virus_scan_failed` - GOV.UK Notify found a potential virus in the precompiled letter file
-* `validation_failed` - content in the precompiled letter file is outside the printable area
-* `technical_failure` - GOV.UK Notify had an unexpected error while sending the letter to their printing provider
-* `permanent_failure` - the provider cannot print the letter, the letter will not be dispatched

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -54,7 +54,7 @@ The `Accept` header can contain the following values:
 * `application/json`
 * `application/vnd.api+json`
 
-The `Accept` header may optionally include a `charset` attribute. If included, it **must** be set to `charset=utf-8` Any other `charset` value will result in a `415` error response. If ommited then `utf-8` is assumed. 
+The `Accept` header may optionally include a `charset` attribute. If included, it **must** be set to `charset=utf-8` Any other `charset` value will result in a `415` error response. If omitted then `utf-8` is assumed. 
 
 Where no `Accept` header is present, this will default to `application/vnd.api+json`
 
@@ -65,7 +65,7 @@ This API will accept request payloads of the following types:
 * `application/vnd.api+json` - see [JSON:API specification](https://jsonapi.org/format/#introduction)
 * `application/json`
 
-The `Content-Type` header may optionally include a `charset` attribute. If included, it **must** be set to `charset=utf-8` Any other `charset` value will result in a `406` error response. If ommited then `utf-8` is assumed. 
+The `Content-Type` header may optionally include a `charset` attribute. If included, it **must** be set to `charset=utf-8` Any other `charset` value will result in a `406` error response. If omitted then `utf-8` is assumed. 
 
 If you attempt to send a payload without the `Content-Type` header set to either of these values then the API will respond with a `415 Unsupported Media Type` response.
 


### PR DESCRIPTION
## Summary
### Message Status Callback
![image](https://github.com/user-attachments/assets/abe8ee3a-b57b-4d87-8468-904a762238b3)

### Channel Status Callback
![image](https://github.com/user-attachments/assets/975e5aaf-117f-4125-9fac-7bf2d988a76c)

### Other changes
Also fixed a relative link under Free-Text Comms
![image](https://github.com/user-attachments/assets/3527b19c-f9e6-44f9-94ea-b1074d3e94ae)

and removed the" Message status" and "Supplier status" sections completely (as the content is now hosted on the external content site)

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
