### PR TITLE
CCM-8392: [API Docs] Add name override fields to msg send endpoints

### DIFF
--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -9,7 +9,7 @@ Use this API to send messages to citizens via NHS App, email, text message or le
 * enrichment of recipient details
 * support for accessible formats and multiple languages
 
-Learn more about [NHS Notify's features](https://digital.nhs.uk/services/nhs-notify/features).
+Learn more about [NHS Notify's features](https://notify.nhs.uk/features/).
 
 ## Who can use this API
 

--- a/specification/schemas/components/Recipient.yaml
+++ b/specification/schemas/components/Recipient.yaml
@@ -8,7 +8,7 @@ properties:
     minLength: 10
     maxLength: 10
     example: "9990548609"
-    description: The [NHS number](https://digital.nhs.uk/services/nhs-number) of the recipient. Only [valid NHS Numbers](https://www.datadictionary.nhs.uk/attributes/nhs_number.html) will be accepted. This will be used to lookup the recipients details with the [Personal Demographics Service](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir).
+    description: The [NHS number](https://digital.nhs.uk/services/nhs-number) of the recipient. Only [valid NHS Numbers](https://www.datadictionary.nhs.uk/attributes/nhs_number.html) will be accepted. This will be used to lookup the recipients details with the [Personal Demographics Service](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir). Normally a required field, unless prior agreement with the Onboarding team is in place to enable the Anonymous Patients feature.
   contactDetails:
     type: object
     description: "Overriding contact details is a sensitive action and requires explicit approval from the onboarding team."
@@ -47,5 +47,27 @@ properties:
             type: string
             description: Postcode of overriding address. A required field when address is specified. Must be a valid UK postcode format.
             example: "LS1 4AP"
-required:
-  - nhsNumber
+      name:
+        type: object
+        description: Overriding name fields for the recipient.
+        properties:
+          prefix:
+            type: string
+            description: Prefix of overriding name.
+            example: Dr.
+          firstName:
+            type: string
+            description: First name of overriding name.
+            example: John
+          middleNames:
+            type: string
+            description: Middle names of overriding name.
+            example: Andrew Robert
+          lastName:
+            type: string
+            description: Last name of overriding name. A required field when name is specified.
+            example: Smith
+          suffix:
+            type: string
+            description: Suffix of overriding name.
+            example: Jr.

--- a/specification/schemas/components/Recipient.yaml
+++ b/specification/schemas/components/Recipient.yaml
@@ -8,7 +8,7 @@ properties:
     minLength: 10
     maxLength: 10
     example: "9990548609"
-    description: The [NHS number](https://digital.nhs.uk/services/nhs-number) of the recipient. Only [valid NHS Numbers](https://www.datadictionary.nhs.uk/attributes/nhs_number.html) will be accepted. This will be used to lookup the recipients details with the [Personal Demographics Service](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir). Normally a required field, unless prior agreement with the Onboarding team is in place to enable the Anonymous Patients feature.
+    description: The [NHS number](https://digital.nhs.uk/services/nhs-number) of the recipient. Only [valid NHS Numbers](https://www.datadictionary.nhs.uk/attributes/nhs_number.html) will be accepted. This will be used to lookup the recipients details with the [Personal Demographics Service](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir). Normally a required field, unless prior agreement with the Onboarding team is in place.
   contactDetails:
     type: object
     description: "Overriding contact details is a sensitive action and requires explicit approval from the onboarding team."


### PR DESCRIPTION
## Summary
Updated the public API documentation to add name fields to Contact Details Override (schema and example payloads) on the send single and send batch endpoints
Removed the "Required" indicator from the `nhsNumber` field and added a note that it is normally mandatory unless agreed with onboarding team.

Also fixed a broken link in the Overview section.

### Send Single schema
![image](https://github.com/user-attachments/assets/17195199-eeef-4ed6-bacd-94a668858dae)

### Send Single example
![image](https://github.com/user-attachments/assets/38e54504-4e1e-4525-8bb4-a7cc7ac0748d)

### Send Single nhsNumber
![image](https://github.com/user-attachments/assets/e5e918ba-0638-4489-a8e2-9ec05c3d6a47)


### Send Batch schema
![image](https://github.com/user-attachments/assets/050b9b72-58a3-40a9-984a-85d57da25981)

### Send Batch example
![image](https://github.com/user-attachments/assets/062eb3ec-25db-450d-854f-83f3b53c577d)

### Send Batch nhsNumber
![image](https://github.com/user-attachments/assets/acf499e1-6caf-47ae-a161-81267c41f058)


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
