### PR TITLE
CCM-9861: [API docs] Override `channelStatus` enum values

### DIFF
--- a/specification/schemas/components/MessageStatus.yaml
+++ b/specification/schemas/components/MessageStatus.yaml
@@ -29,6 +29,9 @@ properties:
               $ref: ../enums/ChannelType.yaml
             channelStatus:
               $ref: ../enums/ChannelStatus.yaml
+              enum:
+                - delivered
+                - failed
       timestamp:
         type: string
         description: Timestamp of the callback event.


### PR DESCRIPTION
Override `channelStatus` enum values when used in MessageStatus callback

## Summary
When used in the MessageStatus callback, the `channelStatus` is populated from the summary information on the RequestItem so will only ever have values for the terminal states: `delivered | failed`. Currently the documentation states that it could also show the intermediate states.

When used on the ChannelStatus callback or the GetStatus endpoint, the payload is populated from the detailed information on the RequestItemPlan so should continue to show the intermediate states.

### Previously
![image](https://github.com/user-attachments/assets/305f6666-e94a-4f7b-a976-3e214dd114da)

### Updated
![image](https://github.com/user-attachments/assets/bb5a6cdf-a473-42d5-b84d-77bd7aba5f88)
![image](https://github.com/user-attachments/assets/bdf97cf3-d2ca-4b74-a995-87f776a7c018)
![image](https://github.com/user-attachments/assets/e9c323af-0ddd-4d18-b52e-f5e4687519a8)

## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [x] 2 reviews received
* [x] Tester approval
