### PR TITLE
CCM-9521: SMS Api Docs for international support

### DIFF
--- a/specification/schemas/components/Recipient.yaml
+++ b/specification/schemas/components/Recipient.yaml
@@ -22,7 +22,10 @@ properties:
         example: "recipient@nhs.net"
       sms:
         type: string
-        description: Overriding mobile telephone number for recipient. Must be a valid mobile number in either UK format (with or without a country code) or international format (starting with a country code).
+        description: |+
+          Overriding mobile number for the recipient. Must be in a valid UK format or international format with a country code.
+
+          Learn more about [sending text messages to international numbers](https://notify.nhs.uk/pricing/text-messages#sending-text-messages-to-international-numbers).
         example: "07777777777"
       address:
         type: object

--- a/specification/schemas/components/Recipient.yaml
+++ b/specification/schemas/components/Recipient.yaml
@@ -22,7 +22,7 @@ properties:
         example: "recipient@nhs.net"
       sms:
         type: string
-        description: Overriding mobile telephone number for recipient. Must be a valid UK (starting 07* or 447*) or international (starting with country access code) format mobile number.
+        description: Overriding mobile telephone number for recipient. Must be a valid mobile number in either UK format (with or without a country code) or international format (starting with a country code).
         example: "07777777777"
       address:
         type: object

--- a/specification/schemas/components/Recipient.yaml
+++ b/specification/schemas/components/Recipient.yaml
@@ -22,7 +22,7 @@ properties:
         example: "recipient@nhs.net"
       sms:
         type: string
-        description: Overriding UK mobile telephone number for recipient. Must be a valid UK mobile number format (with or without international access code).
+        description: Overriding mobile telephone number for recipient. Must be a valid UK (starting 07* or 447*) or international (starting with country access code) format mobile number.
         example: "07777777777"
       address:
         type: object


### PR DESCRIPTION
## Summary

Update API Docs to detail international phone number support for SMS contact override

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
