### PR TITLE
CCM-10161: Added new global routing config to API docs

### DIFF
--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -153,11 +153,12 @@ You'll then need to include this personalisation field in your request.
 ###	Making your request to send messages from your software
 Use the following routing plan IDs and personalisation fields that match the message channel your user will send their message with.
 
-| Message channel | Personalisation field      | Routing plan ID                      | 
-|-----------------|----------------------------|--------------------------------------|
-| NHS App message | body                       | 00000000-0000-0000-0000-000000000001 |
-| Email           | email_subject, email_body  | 00000000-0000-0000-0000-000000000002 |
-| Text message    | sms_body                   | 00000000-0000-0000-0000-000000000003 |
+| Message channel                          | Personalisation field                  | Routing plan ID                      | 
+|------------------------------------------|----------------------------------------|--------------------------------------|
+| NHS App message                          | body                                   | 00000000-0000-0000-0000-000000000001 |
+| Email                                    | email_subject, email_body              | 00000000-0000-0000-0000-000000000002 |
+| Text message                             | sms_body                               | 00000000-0000-0000-0000-000000000003 |
+| NHS App message with a fallback to email | nhsapp_body, email_subject, email_body | 00000000-0000-0000-0000-000000000004 |
 
 For email, use the personalisation field `email_subject` to allow your user to add the email subject line.
 


### PR DESCRIPTION
## Summary
Added details of the new global routing config for NHS App with an Email fallback to the API Docs
![image](https://github.com/user-attachments/assets/7f00e7e0-1f4b-4dc0-a12d-45d5597148d9)


## Reviews Required
* [x] Dev
* [x] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
