### PR TITLE
CCM-10553: Update dependabot to pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/sandbox"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    - package-ecosystem: "pnpm"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+    - package-ecosystem: "npm"
+      directory: "/sandbox"
+      schedule:
+          interval: "weekly"
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+          interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
-    - package-ecosystem: "npm"
+    - package-ecosystem: "pnpm"
       directory: "/sandbox"
       schedule:
           interval: "weekly"


### PR DESCRIPTION
## Summary
Updates the package manager dependabot uses to pnpm instead of npm to hopefully fix #115 security issue.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
