### PR TITLE
CCM-10538: Update API Docs wording on duplicate request period

### DIFF
--- a/specification/responses/4xx/message_batches/422_DuplicateBatchRequest.yaml
+++ b/specification/responses/4xx/message_batches/422_DuplicateBatchRequest.yaml
@@ -1,5 +1,5 @@
 description: |+
-  Request already received and it will be ignored. Note that NHS Notify retains details of your original request for up to 16 months. Duplicate submissions received after this period will still be accepted.
+  Request already received and it will be ignored. Note that NHS Notify retains details of your original request for up to 9 months. Duplicate submissions received after this period will still be accepted.
 
   ### Sandbox
 

--- a/specification/responses/4xx/messages/422_DuplicateMessageRequest.yaml
+++ b/specification/responses/4xx/messages/422_DuplicateMessageRequest.yaml
@@ -1,5 +1,5 @@
 description: |+
-  Request already received and it will be ignored. Note that NHS Notify retains details of your original request for up to 16 months. Duplicate submissions received after this period will still be accepted.
+  Request already received and it will be ignored. Note that NHS Notify retains details of your original request for up to 9 months. Duplicate submissions received after this period will still be accepted.
   ### Sandbox
 
   It is possible to trigger this on the sandbox by using the `Prefer` header with a value of `code=422_message`.


### PR DESCRIPTION
## Summary

This PR updates the API documentation to reflect a change in Notify’s duplicate request period from 16 to 9 months.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
